### PR TITLE
Avoid adding paths to the path list that do not exist

### DIFF
--- a/src/antsibull_nox/sessions.py
+++ b/src/antsibull_nox/sessions.py
@@ -101,7 +101,7 @@ def restrict_paths(paths: list[str], restrict: list[str]) -> list[str]:
         if not match_path(path, is_file, restrict):
             if not is_file:
                 for check in restrict:
-                    if check.startswith(path):
+                    if check.startswith(path) and os.path.exists(check):
                         result.append(check)
             continue
         result.append(path)


### PR DESCRIPTION
I noticed this when trying this out with community.library_inventory_filtering_v1. Pylint failed there because it tried to run on `plugins/modules`, which doesn't exist in that collection.