### PR TITLE
Full REUSE compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,5 +77,5 @@ General Public License v3 or, at your option, later. See
 [LICENSES/GPL-3.0-or-later.txt](https://github.com/ansible-community/antsibull-nox/tree/main/LICENSE)
 for a copy of the license.
 
-The repository follows the [REUSE Specification](https://reuse.software/spec/) for declaring copyright and
-licensing information. The only exception are changelog fragments in ``changelog/fragments/``.
+The repository follows the [REUSE Specification](https://reuse.software/spec/)
+for declaring copyright and licensing information.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Ansible Project
+# SPDX-License-Identifier: GPL-3.0-or-later
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 version = 1
 
 [[annotations]]


### PR DESCRIPTION
- Add REUSE tags to REUSE.toml, the only file (ironically) lacking them.
- Remove the note from the end of README.md about changelog fragments not being REUSE compliant, because the configs in REUSE.toml applies GPL-3.0-or-later to all fragments.