### PR TITLE
Find dependent collections in ../<namespace>.<name> when CWD is not part of ansible_collections tree

### DIFF
--- a/changelogs/fragments/22-adjacent-collections.yml
+++ b/changelogs/fragments/22-adjacent-collections.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - "When a collection checkout is not part of an ``ansible_collections`` tree,
+     look for collections in adjacent directories of the form ``<namespace>.<name>`` that match the containing collection's FQCN
+     (https://github.com/ansible-community/antsibull-nox/issues/6, https://github.com/ansible-community/antsibull-nox/pull/22)."

--- a/src/antsibull_nox/collection.py
+++ b/src/antsibull_nox/collection.py
@@ -14,7 +14,7 @@ import functools
 import json
 import os
 import typing as t
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Collection, Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -168,6 +168,34 @@ def force_collection_version(path: Path, *, version: str) -> bool:
     return True
 
 
+def _list_adjacent_collections_ansible_collections_tree(
+    root: Path,
+    *,
+    directories_to_ignore: Collection[Path] | None = None,
+) -> Iterator[CollectionData]:
+    directories_to_ignore = directories_to_ignore or ()
+    for namespace in root.iterdir():  # pylint: disable=too-many-nested-blocks
+        try:
+            if namespace.is_dir() or namespace.is_symlink():
+                for name in namespace.iterdir():
+                    if name in directories_to_ignore:
+                        continue
+                    try:
+                        if name.is_dir() or name.is_symlink():
+                            yield load_collection_data_from_disk(
+                                name,
+                                namespace=namespace.name,
+                                name=name.name,
+                                root=root,
+                            )
+                    except Exception:  # pylint: disable=broad-exception-caught
+                        # If name doesn't happen to be a (symlink to a) directory, ...
+                        pass
+        except Exception:  # pylint: disable=broad-exception-caught
+            # If namespace doesn't happen to be a (symlink to a) directory, ...
+            pass
+
+
 def _fs_list_local_collections() -> Iterator[CollectionData]:
     root: Path | None = None
 
@@ -192,27 +220,10 @@ def _fs_list_local_collections() -> Iterator[CollectionData]:
         ) from exc
 
     # Search tree
-    if root:  # pylint: disable=too-many-nested-blocks
-        for namespace in root.iterdir():
-            try:
-                if namespace.is_dir() or namespace.is_symlink():
-                    for name in namespace.iterdir():
-                        if name == cwd:
-                            continue
-                        try:
-                            if name.is_dir() or name.is_symlink():
-                                yield load_collection_data_from_disk(
-                                    name,
-                                    namespace=namespace.name,
-                                    name=name.name,
-                                    root=root,
-                                )
-                        except Exception:  # pylint: disable=broad-exception-caught
-                            # If name doesn't happen to be a (symlink to a) directory, ...
-                            pass
-            except Exception:  # pylint: disable=broad-exception-caught
-                # If namespace doesn't happen to be a (symlink to a) directory, ...
-                pass
+    if root:
+        yield from _list_adjacent_collections_ansible_collections_tree(
+            root, directories_to_ignore=(cwd,)
+        )
 
 
 def _galaxy_list_collections(runner: Runner) -> Iterator[CollectionData]:

--- a/tests/unit/test_collection.py
+++ b/tests/unit/test_collection.py
@@ -17,7 +17,7 @@ import os
 from pathlib import Path
 
 import pytest
-from antsibull_fileutils.yaml import store_yaml_file
+from antsibull_fileutils.yaml import load_yaml_file, store_yaml_file
 
 from antsibull_nox.collection import (
     CollectionData,
@@ -27,6 +27,7 @@ from antsibull_nox.collection import (
     _extract_collections_from_extra_deps_file,
     _fs_list_local_collections,
     _galaxy_list_collections,
+    force_collection_version,
     get_collection_list,
     load_collection_data_from_disk,
 )
@@ -357,6 +358,7 @@ def test__fs_list_local_collections(tmp_path: Path) -> None:
     (root / "blah").write_text("nothing")
     (root / "empty").mkdir()
     (root / "foo.baz").mkdir()
+    (root / "1.2").mkdir()
     with chdir(foo_bar):
         result = sorted(_fs_list_local_collections(), key=lambda c: c.full_name)
     assert result == [
@@ -446,6 +448,13 @@ def test__fs_list_local_collections(tmp_path: Path) -> None:
         with pytest.raises(
             ValueError,
             match="^Cannot load current collection's info from.*/something: Cannot parse .*something/galaxy.yml: ",
+        ):
+            list(_fs_list_local_collections())
+
+        (cwd / "galaxy.yml").write_text("[]")
+        with pytest.raises(
+            ValueError,
+            match="^Cannot load current collection's info from.*/something: .*something/galaxy.yml is not a dictionary",
         ):
             list(_fs_list_local_collections())
 
@@ -709,6 +718,12 @@ version: null
         },
         "/galaxy.yml contains namespace 'foo', but was hoping for 'fuu'$",
     ),
+    (
+        "MANIFEST.json",
+        "{}",
+        {"accept_manifest": False},
+        "^Cannot find galaxy.yml in ",
+    ),
 ]
 
 
@@ -788,3 +803,93 @@ def test_get_collection_list(tmp_path) -> None:
         ],
         key=lambda c: c.full_name,
     )
+
+
+FORCE_COLLECTION_VERSION_DATA: list[tuple[str, str, bool, dict[str, t.Any]]] = [
+    (
+        r"""name: foo""",
+        "1.2.3",
+        True,
+        {
+            "name": "foo",
+            "version": "1.2.3",
+        },
+    ),
+    (
+        r"""version: []""",
+        "1.2.3",
+        True,
+        {
+            "version": "1.2.3",
+        },
+    ),
+    (
+        r"""version: 1.2.2""",
+        "1.2.3",
+        True,
+        {
+            "version": "1.2.3",
+        },
+    ),
+    (
+        r"""version: 1.2.3""",
+        "1.2.3",
+        False,
+        {
+            "version": "1.2.3",
+        },
+    ),
+    (
+        r"""
+name: boo
+namespace: foo
+version: null""",
+        "1.2.3",
+        True,
+        {
+            "name": "boo",
+            "namespace": "foo",
+            "version": "1.2.3",
+        },
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "content, version, expected_result, expected_content",
+    FORCE_COLLECTION_VERSION_DATA,
+)
+def test_force_collection_version(
+    content: str,
+    version: str,
+    expected_result: bool,
+    expected_content: dict[str, t.Any],
+    tmp_path: Path,
+) -> None:
+    file = tmp_path / "galaxy.yml"
+    file.write_text(content)
+    result = force_collection_version(tmp_path, version=version)
+    assert result == expected_result
+    assert load_yaml_file(file) == expected_content
+
+
+FORCE_COLLECTION_VERSION_FAIL_DATA: list[tuple[str, str, str]] = [
+    (
+        r"""{""",
+        "1.2.3",
+        "^Cannot parse .*/galaxy.yml: ",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "content, version, expected_match",
+    FORCE_COLLECTION_VERSION_FAIL_DATA,
+)
+def test_force_collection_version_fail(
+    content: str, version: str, expected_match: str, tmp_path: Path
+) -> None:
+    file = tmp_path / "galaxy.yml"
+    file.write_text(content)
+    with pytest.raises(ValueError, match=expected_match):
+        force_collection_version(tmp_path, version=version)


### PR DESCRIPTION
Fixes #6.