### PR TITLE
Allow to have collection root outside of .nox session directory

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -508,6 +508,15 @@ The function `antsibull_nox.sessions.prepare_collections()` accepts the followin
   If set to `True`, Python code can import code from the collections.
   If set to `False`, Python code can **not** import code.
 
+* `install_out_of_tree: bool` (keyword argument, default `False`):
+  Whether to install the `ansible_collections` tree in `$TEMP`
+  instead of the nox session directory.
+  Setting this to `True` is not allowed if `install_in_site_packages=True`.
+  This is necessary when running tools like `ansible-doc` against the tree
+  that do not accept nested `ansible_collections` directory structures,
+  where `ansible_collections` is found below `ansible_collections/<namespace>/<name>`
+  for a collection `<namespace>.<name>`.
+
 * `extra_deps_files: list[str | os.PathLike] | None` (default `None`):
   Paths to [collection requirements files](https://docs.ansible.com/ansible/devel/collections_guide/collections_installing.html#install-multiple-collections-with-a-requirements-file)
   whose collections should be copied into the tree structure.

--- a/src/antsibull_nox/paths.py
+++ b/src/antsibull_nox/paths.py
@@ -10,9 +10,11 @@ Path utilities.
 
 from __future__ import annotations
 
+import atexit
 import functools
 import os
 import shutil
+import tempfile
 from pathlib import Path
 
 from antsibull_fileutils.copier import Copier, GitCopier
@@ -175,8 +177,23 @@ def copy_collection(source: Path, destination: Path) -> None:
     copier.copy(source, destination, exclude_root=[".nox", ".tox"])
 
 
+def create_temp_directory(basename: str) -> Path:
+    """
+    Create a temporary directory outside the nox tree.
+    """
+    directory = tempfile.mkdtemp(prefix=basename)
+    path = Path(directory)
+
+    def cleanup() -> None:
+        remove_path(path)
+
+    atexit.register(cleanup)
+    return path
+
+
 __all__ = [
     "copy_collection",
+    "create_temp_directory",
     "filter_paths",
     "find_data_directory",
     "list_all_files",


### PR DESCRIPTION
This is necessary for antsibull-docs lint-session-docs, as ansible-doc doesn't like to be run in a nested `ansible_collections` tree and will spuriously fail in some situations. (I haven't been able to completely figure out when...)

Ref: https://github.com/ansible/ansible/issues/84909