### PR TITLE
Generate descriptions for sessions

### DIFF
--- a/changelogs/fragments/31-descriptions.yml
+++ b/changelogs/fragments/31-descriptions.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Add descriptions to generated sessions that are shown when running ``nox --list`` (https://github.com/ansible-community/antsibull-nox/pull/31)."


### PR DESCRIPTION
The `nox -l` output for community.dns will look like this:
```
* lint -> Meta session for triggering the following sessions: formatters, codeqa, and typing
* formatters -> Run code formatters: isort and black
* codeqa -> Run code QA: flake8 and pylint
* typing -> Run type checker: mypy
* docs-check -> Run 'antsibull-docs lint-collection-docs'
* license-check -> Run license checkers: reuse and license-check (ensure GPLv3+ for plugins)
* extra-checks -> Run extra checkers: no-unwanted-files (checks for unwanted files in plugins/) and action-groups (validate action groups)
* build-import-check -> Run build and import checkers: build-collection and galaxy-importer (test whether Galaxy will import built collection)
* update-docs-fragments -> Update/check auto-generated parts of docs fragments.
```