### PR TITLE
Integrate ansible-test; allow to create CI matrixes for it

### DIFF
--- a/.pylintrc.automated
+++ b/.pylintrc.automated
@@ -67,6 +67,7 @@ confidence=
 disable=
     locally-disabled,
     too-many-arguments,
+    too-many-lines,
     too-many-locals,
     too-many-positional-arguments,
 

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,10 @@ inputs:
       Should be the directory where the collection's `galaxy.yml` is in, and where the `noxfile.py` is in.
     required: false
     default: .
+outputs:
+  run-nox:
+    description: Output of the 'run nox' step.
+    value: ${{ toJSON(steps.run-nox.outputs) }}
 
 runs:
   using: composite
@@ -66,6 +70,7 @@ runs:
       working-directory: "${{ inputs.working-directory }}"
 
     - name: "Run nox"
+      id: run-nox
       run: |
         nox --verbose --reuse-existing-virtualenvs --no-install${{ inputs.sessions && ' --sessions ' || '' }}${{ inputs.sessions }}${{ inputs.extra-args && ' -- ' || '' }}${{ inputs.extra-args }}
       env:

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,12 @@ inputs:
       Python-version to use. We recommend to stick to the default.
     required: false
     default: "3.13"
+  extra-python-versions:
+    description: |-
+      Newline-separated list of Python versions to install as well.
+      Should be used if other Python versions are needed.
+    required: false
+    default: ""
   sessions:
     description: |-
       Nox sessions to run. By default, all sessions are run.
@@ -33,7 +39,9 @@ runs:
       uses: actions/setup-python@v5
       id: python
       with:
-        python-version: "${{ inputs.python-version }}"
+        python-version: |-
+          ${{ inputs.extra-python-versions }}
+          ${{ inputs.python-version }}
 
     - name: "Install nox and antsibull-nox"
       run: |

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,11 @@ inputs:
       Should be used if other Python versions are needed.
     required: false
     default: ""
+  extra-args:
+    description: |-
+      Additional arguments to pass to the nox run after `--`.
+    required: false
+    default: ""
   sessions:
     description: |-
       Nox sessions to run. By default, all sessions are run.
@@ -53,7 +58,7 @@ runs:
     - name: "Set up nox environments"
       run: |
         echo "::group::Set up nox environments"
-        nox --verbose --install-only ${{ inputs.sessions && '--sessions ' || '' }}${{ inputs.sessions }}
+        nox --verbose --install-only${{ inputs.sessions && ' --sessions ' || '' }}${{ inputs.sessions }}
         echo "::endgroup::"
       env:
         FORCE_COLOR: "1"
@@ -62,7 +67,7 @@ runs:
 
     - name: "Run nox"
       run: |
-        nox --verbose --reuse-existing-virtualenvs --no-install ${{ inputs.sessions && '--sessions ' || '' }}${{ inputs.sessions }}
+        nox --verbose --reuse-existing-virtualenvs --no-install${{ inputs.sessions && ' --sessions ' || '' }}${{ inputs.sessions }}${{ inputs.extra-args && ' -- ' || '' }}${{ inputs.extra-args }}
       env:
         FORCE_COLOR: "1"
       shell: bash

--- a/changelogs/fragments/32-ansible-test.yml
+++ b/changelogs/fragments/32-ansible-test.yml
@@ -1,6 +1,8 @@
 minor_changes:
   - "Add several new functions to add ansible-test runs
      (https://github.com/ansible-community/antsibull-nox/issues/5, https://github.com/ansible-community/antsibull-nox/pull/32)."
+  - "Add function ``add_matrix_generator`` which allows to generate matrixes for CI systems for ansible-test runs
+     (https://github.com/ansible-community/antsibull-nox/pull/32)."
   - "The action allows to install additional Python versions with the new ``extra-python-versions`` option
      (https://github.com/ansible-community/antsibull-nox/pull/32)."
   - "The action allows to pass extra commands after ``--`` with the new ``extra-args`` option

--- a/changelogs/fragments/32-ansible-test.yml
+++ b/changelogs/fragments/32-ansible-test.yml
@@ -3,3 +3,5 @@ minor_changes:
      (https://github.com/ansible-community/antsibull-nox/issues/5, https://github.com/ansible-community/antsibull-nox/pull/32)."
   - "The action allows to install additional Python versions with the new ``extra-python-versions`` option
      (https://github.com/ansible-community/antsibull-nox/pull/32)."
+  - "The action allows to pass extra commands after ``--`` with the new ``extra-args`` option
+     (https://github.com/ansible-community/antsibull-nox/pull/32)."

--- a/changelogs/fragments/32-ansible-test.yml
+++ b/changelogs/fragments/32-ansible-test.yml
@@ -1,3 +1,5 @@
 minor_changes:
   - "Add several new functions to add ansible-test runs
      (https://github.com/ansible-community/antsibull-nox/issues/5, https://github.com/ansible-community/antsibull-nox/pull/32)."
+  - "The action allows to install additional Python versions with the new ``extra-python-versions`` option
+     (https://github.com/ansible-community/antsibull-nox/pull/32)."

--- a/changelogs/fragments/32-ansible-test.yml
+++ b/changelogs/fragments/32-ansible-test.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "Add several new functions to add ansible-test runs
+     (https://github.com/ansible-community/antsibull-nox/issues/5, https://github.com/ansible-community/antsibull-nox/pull/32)."

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -81,7 +81,7 @@ and there are plenty of configuration settings for the indiviual formatters/lint
   By default the formatters and linters run on code files in `plugins/`, `tests/unit/`, and on `noxfile.py`.
   If you have other scripts in your collection that should be checked, you can add them with this option.
 
-### `isort` (part of the `formatters` session):
+### `isort` (part of the `formatters` session)
 
 * `run_isort: bool` (default `True`):
   Whether to run `isort`.
@@ -98,7 +98,7 @@ and there are plenty of configuration settings for the indiviual formatters/lint
   or to pin the version,
   or to install the package from a local repository.
 
-### `black` (part of the `formatters` session):
+### `black` (part of the `formatters` session)
 
 * `run_black: bool` (default `True`):
   Whether to run `black`.
@@ -121,7 +121,7 @@ and there are plenty of configuration settings for the indiviual formatters/lint
   or to pin the version,
   or to install the package from a local repository.
 
-### `flake8` (part of the `codeqa` session):
+### `flake8` (part of the `codeqa` session)
 
 * `run_flake8: bool` (default `True`):
   Whether to run `flake8`.
@@ -138,7 +138,7 @@ and there are plenty of configuration settings for the indiviual formatters/lint
   or to pin the version,
   or to install the package from a local repository.
 
-### `pylint` (part of the `codeqa` session):
+### `pylint` (part of the `codeqa` session)
 
 * `run_pylint: bool` (default `True`):
   Whether to run `pylint`.
@@ -165,7 +165,7 @@ and there are plenty of configuration settings for the indiviual formatters/lint
 * `pylint_extra_deps: list[str] | None` (default `None`):
   Allows to specify further packages to install in this session.
 
-### `mypy` (part of the `typing` session):
+### `mypy` (part of the `typing` session)
 
 * `run_mypy: bool` (default `True`):
   Whether to run `mypy`.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -667,6 +667,10 @@ It accepts the following parameters:
 * `ansible_core_branch_name: str | None` (default `None`):
   Allows to override the branch name when `ansible_core_source == "git"`.
 
+* `handle_coverage: t.Literal["never", "always", "auto"]` (default: `"auto"`):
+  Whether to run `ansible-test coverage xml` after running the `ansible-test` command.
+  If set to `"auto"`, will check whether `--coverage` was passed to `ansible-test`.
+
 #### Example code
 
 This adds a session called `ansible-test-integration-devel-ubuntu2404` that runs integration tests with ansible-core's development branch using its Ubuntu 24.04 container.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -671,6 +671,10 @@ It accepts the following parameters:
   Whether to run `ansible-test coverage xml` after running the `ansible-test` command.
   If set to `"auto"`, will check whether `--coverage` was passed to `ansible-test`.
 
+* `register_name: str | None` (default: `None`):
+  Register session under this name.
+  It will then appear under that name for `antsibull_nox.add_matrix_generator()`.
+
 #### Example code
 
 This adds a session called `ansible-test-integration-devel-ubuntu2404` that runs integration tests with ansible-core's development branch using its Ubuntu 24.04 container.
@@ -683,6 +687,7 @@ antsibull_nox.add_ansible_test_session(
     ansible_test_params=["integration", "--docker", "ubuntu2404", "-v", "--color"],
     default=False,
     ansible_core_version="devel",
+    register_name="integration",
 )
 ```
 
@@ -853,3 +858,26 @@ antsibull_nox.add_ansible_test_integration_sessions_default_container(
     include_devel=True,
 )
 ```
+
+### Generate matrixes for CI systems
+
+The function `antsibull_nox.add_matrix_generator()` allows to add a session that generates matrixes for CI systems.
+
+* The output is written as a JSON file to `$ANTSIBULL_NOX_MATRIX_JSON` if that environment variable is set.
+* The output is written as GitHub Actions output to `$GITHUB_OUTPUT` if that environment variable is set.
+* A text version is always shown.
+
+The top-level variables are as following:
+
+* `sanity`: a list of sessions for ansible-test sanity test runs added with
+  `antsibull_nox.add_ansible_test_sanity_test_session()` or
+  `antsibull_nox.add_all_ansible_test_sanity_test_sessions()`.
+
+* `units`: a list of sessions for ansible-test unit test runs added with
+  `antsibull_nox.add_ansible_test_unit_test_session()` or
+  `antsibull_nox.add_all_ansible_test_unit_test_sessions()`.
+
+* `integration`: a list of sessions for ansible-test integration test runs added with
+  `antsibull_nox.add_ansible_test_integration_sessions_default_container()`.
+
+There might be more top-level variables if `antsibull_nox.add_ansible_test_session()`'s `register_name` parameter is used.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -648,7 +648,7 @@ It accepts the following parameters:
 
 * `ansible_test_params: list[str]` (**required**):
   The parameters to pass to `ansible-test`.
-  For example, `["integration", "--docker", "ubuntu2404", "-v"]`.
+  For example, `["integration", "--docker", "ubuntu2404", "-v", "--color"]`.
 
 * `add_posargs: bool` (default `True`):
   Whether to append positional arguments provided to `nox` to the `ansible-test` command.
@@ -676,7 +676,7 @@ antsibull_nox.add_ansible_test_session(
     name="ansible-test-integration-devel-ubuntu2404",
     description="Run Ubuntu 24.04 integration tests with ansible-core devel",
     extra_deps_files=["tests/integration/requirements.yml"],
-    ansible_test_params=["integration", "--docker", "ubuntu2404", "-v"],
+    ansible_test_params=["integration", "--docker", "ubuntu2404", "-v", "--color"],
     default=False,
     ansible_core_version="devel",
 )

--- a/src/antsibull_nox/__init__.py
+++ b/src/antsibull_nox/__init__.py
@@ -12,6 +12,12 @@ from __future__ import annotations
 
 from .sessions import (
     ActionGroup,
+    add_all_ansible_test_sanity_test_sessions,
+    add_all_ansible_test_unit_test_sessions,
+    add_ansible_test_integration_sessions_default_container,
+    add_ansible_test_sanity_test_session,
+    add_ansible_test_session,
+    add_ansible_test_unit_test_session,
     add_build_import_check,
     add_docs_check,
     add_extra_checks,
@@ -30,4 +36,10 @@ __all__ = (
     "add_extra_checks",
     "add_license_check",
     "add_lint_sessions",
+    "add_ansible_test_session",
+    "add_ansible_test_sanity_test_session",
+    "add_all_ansible_test_sanity_test_sessions",
+    "add_ansible_test_unit_test_session",
+    "add_all_ansible_test_unit_test_sessions",
+    "add_ansible_test_integration_sessions_default_container",
 )

--- a/src/antsibull_nox/__init__.py
+++ b/src/antsibull_nox/__init__.py
@@ -23,6 +23,7 @@ from .sessions import (
     add_extra_checks,
     add_license_check,
     add_lint_sessions,
+    add_matrix_generator,
 )
 
 __version__ = "0.1.0.post0"
@@ -42,4 +43,5 @@ __all__ = (
     "add_ansible_test_unit_test_session",
     "add_all_ansible_test_unit_test_sessions",
     "add_ansible_test_integration_sessions_default_container",
+    "add_matrix_generator",
 )

--- a/src/antsibull_nox/ansible.py
+++ b/src/antsibull_nox/ansible.py
@@ -213,10 +213,6 @@ def get_supported_core_versions(
         ) from exc
 
     result: list[AnsibleCoreVersion] = []
-    if include_devel:
-        result.append("devel")
-    if include_milestone:
-        result.append("milestone")
     for version in version_range(
         _MIN_SUPPORTED_VERSION, _CURRENT_DEVEL_VERSION, inclusive=False
     ):
@@ -227,6 +223,10 @@ def get_supported_core_versions(
         v = PckgVersion(f"{version.major}.{version.minor}.999")
         if v in ra_specifier:
             result.append(version)
+    if include_milestone:
+        result.append("milestone")
+    if include_devel:
+        result.append("devel")
     return result
 
 

--- a/src/antsibull_nox/paths.py
+++ b/src/antsibull_nox/paths.py
@@ -191,8 +191,27 @@ def create_temp_directory(basename: str) -> Path:
     return path
 
 
+def copy_directory_tree_into(source: Path, destination: Path) -> None:
+    """
+    Copy the directory tree from ``source`` into the tree at ``destination``.
+
+    If ``destination`` does not yet exist, it will be created first.
+    """
+    if not source.is_dir():
+        return
+    destination.mkdir(parents=True, exist_ok=True)
+    for root, _, files in source.walk():
+        path = destination / root.relative_to(source)
+        path.mkdir(exist_ok=True)
+        for file in files:
+            dest = path / file
+            remove_path(dest)
+            shutil.copy2(root / file, dest, follow_symlinks=False)
+
+
 __all__ = [
     "copy_collection",
+    "copy_directory_tree_into",
     "create_temp_directory",
     "filter_paths",
     "find_data_directory",

--- a/src/antsibull_nox/sessions.py
+++ b/src/antsibull_nox/sessions.py
@@ -1076,6 +1076,7 @@ def add_ansible_test_session(
     if register_name:
         data = {
             "name": name,
+            "ansible-core": str(parsed_ansible_core_version),
             "python": " ".join(str(python) for python in python_versions),
         }
         if register_extra_data:

--- a/src/antsibull_nox/sessions.py
+++ b/src/antsibull_nox/sessions.py
@@ -36,6 +36,7 @@ from .collection import (
 from .data_util import prepare_data_script
 from .paths import (
     copy_collection,
+    copy_directory_tree_into,
     create_temp_directory,
     filter_paths,
     find_data_directory,
@@ -1010,6 +1011,7 @@ def add_ansible_test_session(
         if not prepared_collections:
             session.warn("Skipping ansible-test...")
             return
+        cwd = Path.cwd()
         with session.chdir(prepared_collections.current_path):
             command = ["ansible-test"] + ansible_test_params
             if add_posargs and session.posargs:
@@ -1032,6 +1034,11 @@ def add_ansible_test_session(
                     "--group-by",
                     "version",
                 )
+
+            copy_directory_tree_into(
+                prepared_collections.current_path / "tests" / "output",
+                cwd / "tests" / "output",
+            )
 
     # Determine Python version(s)
     core_info = get_ansible_core_info(parsed_ansible_core_version)

--- a/src/antsibull_nox/sessions.py
+++ b/src/antsibull_nox/sessions.py
@@ -1051,7 +1051,7 @@ def add_ansible_test_sanity_test_session(
     add_ansible_test_session(
         name=name,
         description=description,
-        ansible_test_params=["sanity", "--docker", "-v"],
+        ansible_test_params=["sanity", "--docker", "-v", "--color"],
         default=default,
         ansible_core_version=ansible_core_version,
         ansible_core_source=ansible_core_source,
@@ -1114,7 +1114,7 @@ def add_ansible_test_unit_test_session(
     add_ansible_test_session(
         name=name,
         description=description,
-        ansible_test_params=["units", "--docker", "-v"],
+        ansible_test_params=["units", "--docker", "-v", "--color"],
         extra_deps_files=["tests/unit/requirements.yml"],
         default=default,
         ansible_core_version=ansible_core_version,
@@ -1214,6 +1214,7 @@ def add_ansible_test_integration_sessions_default_container(
                     "--docker",
                     "default",
                     "-v",
+                    "--color",
                     "--python",
                     str(py_version),
                 ],

--- a/src/antsibull_nox/sessions.py
+++ b/src/antsibull_nox/sessions.py
@@ -982,6 +982,7 @@ def add_ansible_test_session(
     ansible_core_version: str | AnsibleCoreVersion,
     ansible_core_source: t.Literal["git", "pypi"] = "git",
     ansible_core_branch_name: str | None = None,
+    handle_coverage: t.Literal["never", "always", "auto"] = "auto",
 ) -> None:
     """
     Add generic ansible-test session.
@@ -1014,6 +1015,23 @@ def add_ansible_test_session(
             if add_posargs and session.posargs:
                 command.extend(session.posargs)
             session.run(*command)
+
+            coverage = (handle_coverage == "auto" and "--coverage" in command) or (
+                handle_coverage == "always"
+            )
+            if coverage:
+                session.run(
+                    "ansible-test",
+                    "coverage",
+                    "xml",
+                    "--color",
+                    "-v",
+                    "--requirements",
+                    "--group-by",
+                    "command",
+                    "--group-by",
+                    "version",
+                )
 
     # Determine Python version(s)
     core_info = get_ansible_core_info(parsed_ansible_core_version)

--- a/src/antsibull_nox/sessions.py
+++ b/src/antsibull_nox/sessions.py
@@ -994,6 +994,7 @@ def add_ansible_test_session(
     ansible_core_branch_name: str | None = None,
     handle_coverage: t.Literal["never", "always", "auto"] = "auto",
     register_name: str | None = None,
+    register_extra_data: dict[str, t.Any] | None = None,
 ) -> None:
     """
     Add generic ansible-test session.
@@ -1073,13 +1074,13 @@ def add_ansible_test_session(
     )
 
     if register_name:
-        _register(
-            register_name,
-            {
-                "name": name,
-                "python": " ".join(str(python) for python in python_versions),
-            },
-        )
+        data = {
+            "name": name,
+            "python": " ".join(str(python) for python in python_versions),
+        }
+        if register_extra_data:
+            data.update(register_extra_data)
+        _register(register_name, data)
 
 
 def add_ansible_test_sanity_test_session(
@@ -1270,6 +1271,10 @@ def add_ansible_test_integration_sessions_default_container(
                 ansible_core_version=ansible_core_version,
                 default=False,
                 register_name="integration",
+                register_extra_data={
+                    "test-container": "default",
+                    "test-python": str(py_version),
+                },
             )
             integration_sessions_core.append(name)
         return integration_sessions_core

--- a/src/antsibull_nox/utils.py
+++ b/src/antsibull_nox/utils.py
@@ -48,6 +48,17 @@ class Version:
         """
         return Version(self.major, self.minor + 1)
 
+    def previous_minor_version(self) -> Version:
+        """
+        Returns the previous minor version.
+        Raises a ValueError if there is none.
+
+        The major version stays the same, and the minor version is decreased by 1.
+        """
+        if self.minor == 0:
+            raise ValueError("No previous minor version exists")
+        return Version(self.major, self.minor - 1)
+
 
 def version_range(
     start: Version, end: Version, *, inclusive: bool

--- a/src/antsibull_nox/utils.py
+++ b/src/antsibull_nox/utils.py
@@ -40,6 +40,14 @@ class Version:
     def __str__(self) -> str:
         return f"{self.major}.{self.minor}"
 
+    def next_minor_version(self) -> Version:
+        """
+        Returns the next minor version.
+
+        The major version stays the same, and the minor version is increased by 1.
+        """
+        return Version(self.major, self.minor + 1)
+
 
 def version_range(
     start: Version, end: Version, *, inclusive: bool

--- a/tests/unit/test_ansible.py
+++ b/tests/unit/test_ansible.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # SPDX-FileCopyrightText: 2025, Ansible Project
 
+import typing as t
+
 import pytest
 
 from antsibull_nox.ansible import _CURRENT_DEVEL_VERSION as CURRENT_DEVEL_VERSION
@@ -11,7 +13,9 @@ from antsibull_nox.ansible import (
     _CURRENT_MILESTONE_VERSION as CURRENT_MILESTONE_VERSION,
 )
 from antsibull_nox.ansible import (
+    AnsibleCoreVersion,
     get_ansible_core_info,
+    get_ansible_core_package_name,
 )
 from antsibull_nox.python import _PYTHON_VERSIONS_TO_TRY
 from antsibull_nox.utils import Version, version_range
@@ -58,3 +62,83 @@ def test_all_versions() -> None:
     max_py3 = max(all_py3)
     for version in version_range(min_py3, max_py3, inclusive=True):
         assert version in _PYTHON_VERSIONS_TO_TRY
+
+
+GET_ANSIBLE_CORE_PAGAGE_NAME_DATA: list[
+    tuple[AnsibleCoreVersion, dict[str, t.Any], str]
+] = [
+    (
+        Version(2, 9),
+        {},
+        "https://github.com/ansible-community/eol-ansible/archive/stable-2.9.tar.gz",
+    ),
+    (
+        Version(2, 9),
+        {"source": "pypi"},
+        "ansible>=2.9,<2.10",
+    ),
+    (
+        Version(2, 10),
+        {},
+        "https://github.com/ansible-community/eol-ansible/archive/stable-2.10.tar.gz",
+    ),
+    (
+        Version(2, 10),
+        {"source": "pypi"},
+        "ansible-base>=2.10,<2.11",
+    ),
+    (
+        Version(2, 11),
+        {},
+        "https://github.com/ansible-community/eol-ansible/archive/stable-2.11.tar.gz",
+    ),
+    (
+        Version(2, 11),
+        {"source": "pypi"},
+        "ansible-core>=2.11,<2.12",
+    ),
+    # Last EOL version
+    (
+        Version(2, 14),
+        {},
+        "https://github.com/ansible-community/eol-ansible/archive/stable-2.14.tar.gz",
+    ),
+    # First non-EOL version
+    (
+        Version(2, 15),
+        {},
+        "https://github.com/ansible/ansible/archive/stable-2.15.tar.gz",
+    ),
+    # devel
+    (
+        "devel",
+        {},
+        "https://github.com/ansible/ansible/archive/devel.tar.gz",
+    ),
+    (
+        "devel",
+        {"source": "pypi"},
+        "https://github.com/ansible/ansible/archive/devel.tar.gz",
+    ),
+    # milestone
+    (
+        "milestone",
+        {},
+        "https://github.com/ansible/ansible/archive/milestone.tar.gz",
+    ),
+    (
+        "milestone",
+        {"source": "pypi"},
+        "https://github.com/ansible/ansible/archive/milestone.tar.gz",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "version, kwargs, expected_package_name",
+    GET_ANSIBLE_CORE_PAGAGE_NAME_DATA,
+)
+def test_get_ansible_core_package_name(
+    version: AnsibleCoreVersion, kwargs: dict[str, t.Any], expected_package_name: str
+) -> None:
+    assert get_ansible_core_package_name(version, **kwargs) == expected_package_name

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -41,6 +41,14 @@ def test_version_next() -> None:
     assert Version(1, 9).next_minor_version() == Version(1, 10)
 
 
+def test_version_prev() -> None:
+    assert Version(2, 4).previous_minor_version() == Version(2, 3)
+    assert Version(1, 10).previous_minor_version() == Version(1, 9)
+
+    with pytest.raises(ValueError, match="^No previous minor version exists$"):
+        Version(1, 0).previous_minor_version()
+
+
 VERSION_RANGE_DATA: list[tuple[str, str, bool, list[str]]] = [
     (
         "1.2",

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -36,6 +36,11 @@ def test_verison_parse_fail() -> None:
         Version.parse("1.a")
 
 
+def test_version_next() -> None:
+    assert Version(2, 3).next_minor_version() == Version(2, 4)
+    assert Version(1, 9).next_minor_version() == Version(1, 10)
+
+
 VERSION_RANGE_DATA: list[tuple[str, str, bool, list[str]]] = [
     (
         "1.2",


### PR DESCRIPTION
Adds functions to add ansible-test sessions.

Fixes #5.

I've tested this with community.dns by adding the following to its `noxfile.py` (see https://github.com/ansible-collections/community.dns/pull/255):
```python
antsibull_nox.add_all_ansible_test_sanity_test_sessions(include_devel=True)
antsibull_nox.add_all_ansible_test_unit_test_sessions(include_devel=True)
antsibull_nox.add_ansible_test_integration_sessions_default_container(
    core_python_versions={
        "2.14": ["2.7", "3.5", "3.9"],
        "2.15": ["3.7"],
        "2.16": ["2.7", "3.6", "3.11"],
        "2.17": ["3.7", "3.12"],
        "2.18": ["3.8", "3.13"],
    },
    include_devel=True,
)
```
This basically runs everything that's also run by https://github.com/ansible-collections/community.dns/blob/main/.github/workflows/ansible-test.yml.
