### PR TITLE
Remove 'extra-collections-*' parameters from shared workflow

### DIFF
--- a/.github/workflows/reusable-nox-matrix.yml
+++ b/.github/workflows/reusable-nox-matrix.yml
@@ -25,24 +25,6 @@ name: Run sanity, unit, and integration tests
           Whether code coverage should be collected and uploaded to codecov.io.
         required: false
         default: false
-      extra-collections-sanity:
-        type: string
-        description: >-
-          Additional collections to install for sanity tests.
-        required: false
-        default: ""
-      extra-collections-unit:
-        type: string
-        description: >-
-          Additional collections to install for unit tests.
-        required: false
-        default: ""
-      extra-collections-integration:
-        type: string
-        description: >-
-          Additional collections to install for integration tests.
-        required: false
-        default: ""
     secrets:
       CODECOV_TOKEN:
         required: false
@@ -85,13 +67,6 @@ jobs:
         with:
           path: ansible_collections/${{ inputs.collection-namespace }}/${{ inputs.collection-name }}
           persist-credentials: false
-      - name: Check out dependent collections
-        if: >-
-          !matrix.skip && inputs.extra-collections-sanity
-        run: >-
-          ansible-galaxy collection install -p .
-          ${{ inputs.extra-collections-sanity }}
-          git+https://github.com/ansible-collections/community.library_inventory_filtering.git,stable-1
       - name: Run nox
         if: >-
           !matrix.skip
@@ -126,12 +101,6 @@ jobs:
         with:
           path: ansible_collections/${{ inputs.collection-namespace }}/${{ inputs.collection-name }}
           persist-credentials: false
-      - name: Check out dependent collections
-        if: >-
-          !matrix.skip && inputs.extra-collections-unit
-        run: >-
-          ansible-galaxy collection install -p .
-          ${{ inputs.extra-collections-unit }}
       - name: Run nox
         if: >-
           !matrix.skip
@@ -167,12 +136,6 @@ jobs:
         with:
           path: ansible_collections/${{ inputs.collection-namespace }}/${{ inputs.collection-name }}
           persist-credentials: false
-      - name: Check out dependent collections
-        if: >-
-          !matrix.skip && inputs.extra-collections-integration
-        run: >-
-          ansible-galaxy collection install -p .
-          ${{ inputs.extra-collections-integration }}
       - name: Run nox
         if: >-
           !matrix.skip

--- a/changelogs/fragments/37-shared-workflow.yml
+++ b/changelogs/fragments/37-shared-workflow.yml
@@ -2,4 +2,5 @@ minor_changes:
   - "Add shared workflow for running ansible-test from nox and generating the CI matrix from nox as well
      (https://github.com/ansible-community/antsibull-nox/issues/35,
       https://github.com/ansible-community/antsibull-nox/pull/37,
-      https://github.com/ansible-community/antsibull-nox/pull/38)."
+      https://github.com/ansible-community/antsibull-nox/pull/38,
+      https://github.com/ansible-community/antsibull-nox/pull/48)."

--- a/docs/nox-in-ci.md
+++ b/docs/nox-in-ci.md
@@ -92,14 +92,6 @@ jobs:
       collection-namespace: community
       collection-name: dns
       upload-codecov: true
-      extra-collections-sanity: >-
-        git+https://github.com/ansible-collections/community.library_inventory_filtering.git,stable-1
-      extra-collections-unit: >-
-        git+https://github.com/ansible-collections/community.internal_test_tools.git,main
-        git+https://github.com/ansible-collections/community.library_inventory_filtering.git,stable-1
-      extra-collections-integration: >-
-        git+https://github.com/ansible-collections/community.general.git,main
-        git+https://github.com/ansible-collections/community.library_inventory_filtering.git,stable-1
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 ```


### PR DESCRIPTION
These are no longer needed since antsibull-nox can install the dependencies by itself.