### PR TITLE
Do not use installed collections if environment variable is set

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -75,5 +75,6 @@ runs:
         nox --verbose --reuse-existing-virtualenvs --no-install${{ inputs.sessions && ' --sessions ' || '' }}${{ inputs.sessions }}${{ inputs.extra-args && ' -- ' || '' }}${{ inputs.extra-args }}
       env:
         FORCE_COLOR: "1"
+        ANTSIBULL_NOX_IGNORE_INSTALLED_COLLECTIONS: "true"
       shell: bash
       working-directory: "${{ inputs.working-directory }}"

--- a/changelogs/fragments/51-use-installed.yml
+++ b/changelogs/fragments/51-use-installed.yml
@@ -1,0 +1,7 @@
+minor_changes:
+  - "In the GitHub Action, no longer use installed collections, but only ones that have been checked out next to the current one.
+     This avoids using collections that come with the Ansible community package installed in the default GHA image
+     (https://github.com/ansible-community/antsibull-nox/pull/51)."
+  - "Allow to disable using installed collections that are not checked out next to the current one
+     by setting the environment variable ``ANTSIBULL_NOX_IGNORE_INSTALLED_COLLECTIONS`` to ``true``
+     (https://github.com/ansible-community/antsibull-nox/pull/51)."

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -134,3 +134,27 @@ uv run noxfile.py -Re formatters
     Whether or not a collection has a `formatters` section depends on the parameters passed to `antsibull_nox.add_lint_sessions()` in the `noxfile.py` file.
     In the example in the previous section, `run_isort=False` and `run_black=False` disable both currently supported formatters.
     In this case, `antsibull-nox` does not add the `formatters` session because it would be empty.
+
+## Dependent collections
+
+By default, antsibull-nox will use `ansible-galaxy collection list` to find collections,
+will look in adjacent directories,
+and will download and install missing collections needed to run tests in the `.nox` cache directory.
+
+More precisely:
+
+1. If the current checked out collection is part of a tree structure `ansible_collections/<namespace>/<name>/`,
+   then antsibull-nox will inspect all collections that are part of that tree and use them.
+
+1. If the current checked out collection is not part of such a tree structure,
+   then antsibull-nox will look for adjacent directories of the form `<namespace>.<name>`.
+
+1. If the environment variable `ANTSIBULL_NOX_IGNORE_INSTALLED_COLLECTIONS` is not set to `true`,
+   antibull-nox will call `ansible-galaxy collection list` to find all installed collections.
+
+1. If more collections are needed,
+   and `ANTSIBULL_NOX_INSTALL_COLLECTIONS` is not set to `never`,
+   antsibull-nox will download and install them into the `.nox` cache directory.
+
+In the included GitHub Action, `ANTSIBULL_NOX_IGNORE_INSTALLED_COLLECTIONS` is always set to `true`.
+This avoids using collections from the Ansible community package that is installed in GitHub's default images.

--- a/src/antsibull_nox/collection/search.py
+++ b/src/antsibull_nox/collection/search.py
@@ -11,6 +11,7 @@ Handle Ansible collections.
 from __future__ import annotations
 
 import json
+import os
 import threading
 import typing as t
 from collections.abc import Collection, Iterator, Sequence
@@ -281,10 +282,11 @@ class CollectionList:
         found_collections = {}
         for collection_data in _fs_list_local_collections():
             found_collections[collection_data.full_name] = collection_data
-        for collection_data in _galaxy_list_collections(runner):
-            # Similar to Ansible, we use the first match
-            if collection_data.full_name not in found_collections:
-                found_collections[collection_data.full_name] = collection_data
+        if os.environ.get("ANTSIBULL_NOX_IGNORE_INSTALLED_COLLECTIONS") != "true":
+            for collection_data in _galaxy_list_collections(runner):
+                # Similar to Ansible, we use the first match
+                if collection_data.full_name not in found_collections:
+                    found_collections[collection_data.full_name] = collection_data
         for collection_data in _fs_list_global_cache(global_cache.extracted_cache):
             # Similar to Ansible, we use the first match
             if collection_data.full_name not in found_collections:


### PR DESCRIPTION
Currently the community.dns unit tests fail. For `devel`, they need a DT compatible version of `community.library_inventory_filtering_v1`, but GitHub's default image has an older Ansible release installed, and antsibull-nox uses its `community.library_inventory_filtering_v1` instead of installing that collection from Git.

For that reason I generally disabled using installed collections in the GHA action by providing an environment variable to disable that, and using that one in the GH Action.