### PR TITLE
Remove collection namespace and name parameter from shared workflow

### DIFF
--- a/.github/workflows/reusable-nox-matrix.yml
+++ b/.github/workflows/reusable-nox-matrix.yml
@@ -9,16 +9,6 @@ name: Run sanity, unit, and integration tests
 "on":
   workflow_call:
     inputs:
-      collection-namespace:
-        description: >-
-          The collection's namespace.
-        type: string
-        required: true
-      collection-name:
-        description: >-
-          The collection's name.
-        type: string
-        required: true
       upload-codecov:
         type: boolean
         description: >-
@@ -41,13 +31,11 @@ jobs:
       - name: Check out collection
         uses: actions/checkout@v4
         with:
-          path: ansible_collections/${{ inputs.collection-namespace }}/${{ inputs.collection-name }}
           persist-credentials: false
       - name: Run nox
         uses: ansible-community/antsibull-nox@main
         id: generate-matrix
         with:
-          working-directory: ansible_collections/${{ inputs.collection-namespace }}/${{ inputs.collection-name }}
           sessions: matrix-generator
 
   sanity:
@@ -65,14 +53,12 @@ jobs:
           !matrix.skip
         uses: actions/checkout@v4
         with:
-          path: ansible_collections/${{ inputs.collection-namespace }}/${{ inputs.collection-name }}
           persist-credentials: false
       - name: Run nox
         if: >-
           !matrix.skip
         uses: ansible-community/antsibull-nox@main
         with:
-          working-directory: ansible_collections/${{ inputs.collection-namespace }}/${{ inputs.collection-name }}
           extra-python-versions: ${{ matrix.python }}
           extra-args: ${{ inputs.upload-codecov && '--coverage' || '' }}
           sessions: ${{ matrix.name }}
@@ -82,7 +68,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage-sanity-${{ matrix.name }}
-          path: ansible_collections/${{ inputs.collection-namespace }}/${{ inputs.collection-name }}/tests/output/reports/coverage=sanity=*.xml
+          path: tests/output/reports/coverage=sanity=*.xml
 
   units:
     name: ${{ matrix.skip && 'Skipping ' || '' }}Units (Ⓐ${{ matrix.ansible-core }})
@@ -99,14 +85,12 @@ jobs:
           !matrix.skip
         uses: actions/checkout@v4
         with:
-          path: ansible_collections/${{ inputs.collection-namespace }}/${{ inputs.collection-name }}
           persist-credentials: false
       - name: Run nox
         if: >-
           !matrix.skip
         uses: ansible-community/antsibull-nox@main
         with:
-          working-directory: ansible_collections/${{ inputs.collection-namespace }}/${{ inputs.collection-name }}
           extra-python-versions: ${{ matrix.python }}
           extra-args: ${{ inputs.upload-codecov && '--coverage' || '' }}
           sessions: ${{ matrix.name }}
@@ -116,7 +100,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage-units-${{ matrix.name }}
-          path: ansible_collections/${{ inputs.collection-namespace }}/${{ inputs.collection-name }}/tests/output/reports/coverage=units=*.xml
+          path: tests/output/reports/coverage=units=*.xml
 
   integration:
     name: ${{ matrix.skip && 'Skipping ' || '' }}I (Ⓐ${{ matrix.ansible-core }}+py${{ matrix.test-python }}+${{ matrix.test-container }})
@@ -134,14 +118,12 @@ jobs:
           !matrix.skip
         uses: actions/checkout@v4
         with:
-          path: ansible_collections/${{ inputs.collection-namespace }}/${{ inputs.collection-name }}
           persist-credentials: false
       - name: Run nox
         if: >-
           !matrix.skip
         uses: ansible-community/antsibull-nox@main
         with:
-          working-directory: ansible_collections/${{ inputs.collection-namespace }}/${{ inputs.collection-name }}
           extra-python-versions: ${{ matrix.python }}
           extra-args: ${{ inputs.upload-codecov && '--coverage' || '' }}
           sessions: ${{ matrix.name }}
@@ -151,7 +133,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage-integration-${{ matrix.name }}
-          path: ansible_collections/${{ inputs.collection-namespace }}/${{ inputs.collection-name }}/tests/output/reports/coverage=integration=*.xml
+          path: tests/output/reports/coverage=integration=*.xml
 
   upload-coverage:
     name: Upload coverage
@@ -165,18 +147,16 @@ jobs:
       - name: Check out collection
         uses: actions/checkout@v4
         with:
-          path: ansible_collections/${{ inputs.collection-namespace }}/${{ inputs.collection-name }}
           persist-credentials: false
       - name: Download coverage from previous steps
         uses: actions/download-artifact@v4
         with:
-          path: ansible_collections/${{ inputs.collection-namespace }}/${{ inputs.collection-name }}/
           pattern: code-coverage-*
       - name: List all files
-        run: find ansible_collections/${{ inputs.collection-namespace }}/${{ inputs.collection-name }}/ -name 'coverage=*.xml'
+        run: find . -name 'coverage=*.xml'
         shell: bash
       - name: Upload coverage
         uses: codecov/codecov-action@v5
         with:
-          files: ansible_collections/${{ inputs.collection-namespace }}/${{ inputs.collection-name }}/coverage=*.xml
+          files: coverage=*.xml
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/changelogs/fragments/37-shared-workflow.yml
+++ b/changelogs/fragments/37-shared-workflow.yml
@@ -3,4 +3,5 @@ minor_changes:
      (https://github.com/ansible-community/antsibull-nox/issues/35,
       https://github.com/ansible-community/antsibull-nox/pull/37,
       https://github.com/ansible-community/antsibull-nox/pull/38,
-      https://github.com/ansible-community/antsibull-nox/pull/48)."
+      https://github.com/ansible-community/antsibull-nox/pull/48,
+      https://github.com/ansible-community/antsibull-nox/pull/53)."


### PR DESCRIPTION
The directory structure isn't needed.

Also if we ever need the namespace/name at some point, we can fetch it from galaxy.yml during the first step.