### PR TITLE
Add configuration linter

### DIFF
--- a/changelogs/fragments/56-config-lint.yml
+++ b/changelogs/fragments/56-config-lint.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - "Add a ``antsibull-nox`` CLI tool with a subcommand ``lint-config`` that lints the config file (https://github.com/ansible-community/antsibull-nox/pull/56)."
+  - "Add a ``antsibull-nox`` CLI tool with a subcommand ``lint-config`` that lints ``noxfile.py`` and the ``antsibull-nox.toml`` config file (https://github.com/ansible-community/antsibull-nox/pull/56)."
   - "Add a session for linting the antsibull-nox configuration to ``lint`` (https://github.com/ansible-community/antsibull-nox/pull/56)."

--- a/changelogs/fragments/56-config-lint.yml
+++ b/changelogs/fragments/56-config-lint.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Add a ``antsibull-nox`` CLI tool with a subcommand ``lint-config`` that lints the config file (https://github.com/ansible-community/antsibull-nox/pull/56)."

--- a/changelogs/fragments/56-config-lint.yml
+++ b/changelogs/fragments/56-config-lint.yml
@@ -1,2 +1,3 @@
 minor_changes:
   - "Add a ``antsibull-nox`` CLI tool with a subcommand ``lint-config`` that lints the config file (https://github.com/ansible-community/antsibull-nox/pull/56)."
+  - "Add a session for linting the antsibull-nox configuration to ``lint`` (https://github.com/ansible-community/antsibull-nox/pull/56)."

--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -270,6 +270,11 @@ and there are plenty of configuration settings for the indiviual formatters/lint
   Allows to specify further packages to install in this session.
   This can be used for typing stubs like `types-PyYAML`, `types-mock`, and so on.
 
+### `antsibull-nox-config` (part of `lint` session)
+
+* `run_antsibullnox_config_lint: bool` (default: `True`):
+  Lints the antsibull-nox configuration.
+
 ### Example code
 
 This example is from `community.dns`,

--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -272,7 +272,7 @@ and there are plenty of configuration settings for the indiviual formatters/lint
 
 ### `antsibull-nox-config` (part of `lint` session)
 
-* `run_antsibullnox_config_lint: bool` (default: `True`):
+* `run_antsibullnox_config_lint: bool` (default: `true`):
   Lints the antsibull-nox configuration.
 
 ### Example code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ dependencies = [
 "Bug tracker" = "https://github.com/ansible-community/antsibull-nox/issues"
 "Changelog" = "https://github.com/ansible-community/antsibull-nox/tree/main/CHANGELOG.md"
 
+[project.scripts]
+antsibull-nox = "antsibull_nox.cli:main"
+
 
 [project.optional-dependencies]
 #

--- a/src/antsibull_nox/__init__.py
+++ b/src/antsibull_nox/__init__.py
@@ -10,7 +10,10 @@ Antsibull Nox Helper.
 
 from __future__ import annotations
 
-from .config import load_config_from_toml
+from .config import (
+    CONFIG_FILENAME,
+    load_config_from_toml,
+)
 from .interpret_config import interpret_config
 from .sessions.ansible_test import add_ansible_test_session
 
@@ -21,7 +24,7 @@ def load_antsibull_nox_toml() -> None:
     """
     Load and interpret antsibull-nox.toml config file.
     """
-    config = load_config_from_toml("antsibull-nox.toml")
+    config = load_config_from_toml(CONFIG_FILENAME)
     interpret_config(config)
 
 

--- a/src/antsibull_nox/_pydantic.py
+++ b/src/antsibull_nox/_pydantic.py
@@ -1,0 +1,98 @@
+# Author: Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: Ansible Project, 2024
+
+# ========================================================================
+# **Vendored** from antsibull-core.
+#
+# I vendored this to avoid depending on antsibull-core only for this.
+# TBH, most of this should be part of pydantic anyway. See
+# https://github.com/pydantic/pydantic/discussions/2652 for a discussion
+# on this.
+#
+# pylint: disable=missing-function-docstring
+# ========================================================================
+
+"""
+Helpers for pydantic.
+"""
+
+from __future__ import annotations
+
+import typing as t
+from collections.abc import Callable, Collection
+
+import pydantic as p
+
+if t.TYPE_CHECKING:
+    from typing_extensions import TypeGuard
+
+
+def _is_basemodel(a_type: t.Any) -> TypeGuard[type[p.BaseModel]]:
+    try:
+        return issubclass(a_type, p.BaseModel)
+    except TypeError:
+        # If inspect.isclass(a_type) is checked first, no TypeError happens for
+        # Python 3.11+.
+
+        # On Python 3.9 and 3.10, issubclass(dict[int, int], p.BaseModel) raises
+        # "TypeError: issubclass() arg 1 must be a class".
+        # (https://github.com/pydantic/pydantic/discussions/5970)
+        return False
+
+
+def _modify_config(
+    cls: type[p.BaseModel],
+    processed_classes: set[type[p.BaseModel]],
+    change_config: Callable[[p.ConfigDict], bool],
+) -> bool:
+    if cls in processed_classes:
+        return False
+    change = False
+    for field_info in cls.model_fields.values():
+        if _is_basemodel(field_info.annotation):
+            change |= _modify_config(
+                field_info.annotation,
+                processed_classes,
+                change_config,
+            )
+        for subcls in t.get_args(field_info.annotation):
+            if _is_basemodel(subcls):
+                change |= _modify_config(subcls, processed_classes, change_config)
+    change |= change_config(cls.model_config)
+    if change:
+        cls.model_rebuild(force=True)
+    processed_classes.add(cls)
+    return change
+
+
+def set_extras(
+    models: type[p.BaseModel] | Collection[type[p.BaseModel]],
+    value: t.Literal["allow", "ignore", "forbid"],
+) -> None:
+    def change_config(model_config: p.ConfigDict) -> bool:
+        if model_config.get("extra") == value:
+            return False
+        model_config["extra"] = value
+        return True
+
+    processed_classes: set[type[p.BaseModel]] = set()
+    if isinstance(models, Collection):
+        for cls in models:
+            _modify_config(cls, processed_classes, change_config)
+    else:
+        _modify_config(models, processed_classes, change_config)
+
+
+def forbid_extras(models: type[p.BaseModel] | Collection[type[p.BaseModel]]) -> None:
+    set_extras(models, "forbid")
+
+
+def get_formatted_error_messages(error: p.ValidationError) -> list[str]:
+    def format_error(err) -> str:
+        location = " -> ".join(str(loc) for loc in err["loc"])
+        return f'{location}: {err["msg"]}'
+
+    return [format_error(err) for err in error.errors()]

--- a/src/antsibull_nox/cli.py
+++ b/src/antsibull_nox/cli.py
@@ -1,0 +1,113 @@
+# Author: Toshio Kuratomi <tkuratom@redhat.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2020, Ansible Project
+
+# PYTHON_ARGCOMPLETE_OK
+
+"""Entrypoint to the antsibull-docs script."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import os.path
+import sys
+from collections.abc import Callable
+
+from . import __version__
+from .config import lint_config_toml
+
+try:
+    import argcomplete
+
+    HAS_ARGCOMPLETE = True
+except ImportError:
+    HAS_ARGCOMPLETE = False
+
+
+def lint_config() -> int:
+    """
+    Lint antsibull-nox config file.
+    """
+    errors = lint_config_toml()
+    for error in errors:
+        print(error)
+    return 0 if len(errors) == 0 else 3
+
+
+#: Mapping from command line subcommand names to functions which implement those
+#: The functions need to take a single argument, the processed list of args.
+ARGS_MAP: dict[str, Callable[[], int]] = {
+    "lint-config": lint_config,
+}
+
+
+class InvalidArgumentError(Exception):
+    """
+    Error while parsing arguments.
+    """
+
+
+def parse_args(program_name: str, args: list[str]) -> argparse.Namespace:
+    """
+    Parse and coerce the command line arguments.
+    """
+
+    toplevel_parser = argparse.ArgumentParser(
+        prog=program_name,
+        description="Script to manage generated documentation for ansible",
+    )
+    toplevel_parser.add_argument(
+        "--version",
+        action="version",
+        version=__version__,
+        help="Print the antsibull-nox version",
+    )
+    subparsers = toplevel_parser.add_subparsers(
+        title="Subcommands", dest="command", help="for help use: `SUBCOMMANDS -h`"
+    )
+    subparsers.required = True
+
+    subparsers.add_parser(
+        "lint-config",
+        description="Lint antsibull-nox configuration file",
+    )
+
+    # This must come after all parser setup
+    if HAS_ARGCOMPLETE:
+        argcomplete.autocomplete(toplevel_parser)
+
+    parsed_args: argparse.Namespace = toplevel_parser.parse_args(args)
+    return parsed_args
+
+
+def run(args: list[str]) -> int:
+    """
+    Run the program.
+    """
+    program_name = os.path.basename(args[0])
+    try:
+        parsed_args: argparse.Namespace = parse_args(program_name, args[1:])
+    except InvalidArgumentError as e:
+        print(e, file=sys.stderr)
+        return 2
+
+    return ARGS_MAP[parsed_args.command]()
+
+
+def main() -> int:
+    """
+    Entrypoint called from the script.
+
+    Return codes:
+        :0: Success
+        :1: Unhandled error.  See the Traceback for more information.
+        :2: There was a problem with the command line arguments
+    """
+    return run(sys.argv)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/antsibull_nox/cli.py
+++ b/src/antsibull_nox/cli.py
@@ -17,7 +17,7 @@ import sys
 from collections.abc import Callable
 
 from . import __version__
-from .config import lint_config_toml
+from .lint_config import lint_config as _lint_config
 
 try:
     import argcomplete
@@ -31,7 +31,7 @@ def lint_config(_: argparse.Namespace) -> int:
     """
     Lint antsibull-nox config file.
     """
-    errors = lint_config_toml()
+    errors = _lint_config()
     for error in errors:
         print(error)
     return 0 if len(errors) == 0 else 3

--- a/src/antsibull_nox/cli.py
+++ b/src/antsibull_nox/cli.py
@@ -1,8 +1,8 @@
-# Author: Toshio Kuratomi <tkuratom@redhat.com>
+# Author: Felix Fontein <felix@fontein.de>
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
 # https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
-# SPDX-FileCopyrightText: 2020, Ansible Project
+# SPDX-FileCopyrightText: 2025, Ansible Project
 
 # PYTHON_ARGCOMPLETE_OK
 
@@ -27,7 +27,7 @@ except ImportError:
     HAS_ARGCOMPLETE = False
 
 
-def lint_config() -> int:
+def lint_config(_: argparse.Namespace) -> int:
     """
     Lint antsibull-nox config file.
     """
@@ -37,9 +37,9 @@ def lint_config() -> int:
     return 0 if len(errors) == 0 else 3
 
 
-#: Mapping from command line subcommand names to functions which implement those
-#: The functions need to take a single argument, the processed list of args.
-ARGS_MAP: dict[str, Callable[[], int]] = {
+# Mapping from command line subcommand names to functions which implement those.
+# The functions need to take a single argument, the processed list of args.
+ARGS_MAP: dict[str, Callable[[argparse.Namespace], int]] = {
     "lint-config": lint_config,
 }
 
@@ -52,7 +52,7 @@ class InvalidArgumentError(Exception):
 
 def parse_args(program_name: str, args: list[str]) -> argparse.Namespace:
     """
-    Parse and coerce the command line arguments.
+    Parse the command line arguments.
     """
 
     toplevel_parser = argparse.ArgumentParser(
@@ -94,7 +94,7 @@ def run(args: list[str]) -> int:
         print(e, file=sys.stderr)
         return 2
 
-    return ARGS_MAP[parsed_args.command]()
+    return ARGS_MAP[parsed_args.command](parsed_args)
 
 
 def main() -> int:

--- a/src/antsibull_nox/config.py
+++ b/src/antsibull_nox/config.py
@@ -48,6 +48,18 @@ def _parse_ansible_core_version(value: t.Any) -> AnsibleCoreVersion:
     raise ValueError("Must be ansible-core version string")
 
 
+def _validate_collection_name(value: str) -> str:
+    parts = value.split(".")
+    if len(parts) != 2:
+        raise ValueError("Collection name must be of the form '<namespace>.<name>'")
+    if not parts[0].isidentifier():
+        raise ValueError("Collection namespace must be Python identifier")
+    if not parts[1].isidentifier():
+        raise ValueError("Collection name must be Python identifier")
+    return value
+
+
+CollectionName = t.Annotated[str, p.AfterValidator(_validate_collection_name)]
 PVersion = t.Annotated[Version, p.BeforeValidator(_parse_version)]
 PAnsibleCoreVersion = t.Annotated[
     AnsibleCoreVersion, p.BeforeValidator(_parse_ansible_core_version)
@@ -115,7 +127,7 @@ class SessionDocsCheck(_BaseModel):
     antsibull_docs_package: str = "antsibull-docs"
     ansible_core_package: str = "ansible-core"
     validate_collection_refs: t.Optional[t.Literal["self", "dependent", "all"]] = None
-    extra_collections: list[str] = []
+    extra_collections: list[CollectionName] = []
 
 
 class SessionLicenseCheck(_BaseModel):
@@ -319,7 +331,7 @@ class Config(_BaseModel):
     The contents of a antsibull-nox config file.
     """
 
-    collection_sources: dict[str, CollectionSource] = {}
+    collection_sources: dict[CollectionName, CollectionSource] = {}
     sessions: Sessions = Sessions()
 
 

--- a/src/antsibull_nox/config.py
+++ b/src/antsibull_nox/config.py
@@ -117,6 +117,9 @@ class SessionLint(_BaseModel):
     mypy_ansible_core_package: t.Optional[str] = "ansible-core"
     mypy_extra_deps: list[str] = []
 
+    # antsibull-nox config lint:
+    run_antsibullnox_config_lint: bool = True
+
 
 class SessionDocsCheck(_BaseModel):
     """

--- a/src/antsibull_nox/config.py
+++ b/src/antsibull_nox/config.py
@@ -24,6 +24,9 @@ except ImportError:
     from tomli import load as _load_toml  # type: ignore
 
 
+CONFIG_FILENAME = "antsibull-nox.toml"
+
+
 def _parse_version(value: t.Any) -> Version:
     if isinstance(value, Version):
         return value

--- a/src/antsibull_nox/config.py
+++ b/src/antsibull_nox/config.py
@@ -367,6 +367,8 @@ def lint_config_toml() -> list[str]:
             errors.append(f"{path}:{error}")
     except ValueError as exc:
         errors.append(f"{path}:{exc}")
+    except FileNotFoundError:
+        errors.append(f"{path}: File does not exist")
     except IOError as exc:
         errors.append(f"{path}:{exc}")
     return errors

--- a/src/antsibull_nox/data/antsibull-nox-lint-config.py
+++ b/src/antsibull_nox/data/antsibull-nox-lint-config.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2025, Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt
+# or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Run antsibull-nox lint-config."""
+
+from __future__ import annotations
+
+import sys
+
+from antsibull_nox.data.antsibull_nox_data_util import setup
+from antsibull_nox.lint_config import lint_config
+
+
+def main() -> int:
+    """Main entry point."""
+    _, __ = setup()
+
+    errors = lint_config()
+    for error in errors:
+        print(error)
+    return len(errors) > 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/antsibull_nox/interpret_config.py
+++ b/src/antsibull_nox/interpret_config.py
@@ -118,6 +118,7 @@ def _add_sessions(sessions: Sessions) -> None:
             mypy_package=sessions.lint.mypy_package,
             mypy_ansible_core_package=sessions.lint.mypy_ansible_core_package,
             mypy_extra_deps=sessions.lint.mypy_extra_deps,
+            run_antsibullnox_config_lint=sessions.lint.run_antsibullnox_config_lint,
         )
     if sessions.docs_check:
         add_docs_check(

--- a/src/antsibull_nox/lint_config.py
+++ b/src/antsibull_nox/lint_config.py
@@ -1,0 +1,22 @@
+# Author: Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2025, Ansible Project
+
+"""Lint antsibull-nox config."""
+
+from __future__ import annotations
+
+from .config import lint_config_toml
+
+
+def lint_config() -> list[str]:
+    """
+    Lint antsibull-nox config file.
+    """
+    errors = lint_config_toml()
+    return sorted(errors)
+
+
+__all__ = ["lint_config"]

--- a/src/antsibull_nox/lint_config.py
+++ b/src/antsibull_nox/lint_config.py
@@ -8,7 +8,94 @@
 
 from __future__ import annotations
 
+import ast
+
 from .config import lint_config_toml
+
+
+def _is_antsibull_nox_module(module_name: str) -> bool:
+    return module_name == "antsibull_nox" or module_name.startswith("antsibull_nox.")
+
+
+class _Walker:
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.imports: dict[str, str] = {}
+        self.has_config_load = False
+
+    @staticmethod
+    def _get_name(what: ast.expr) -> str | None:
+        if isinstance(what, ast.Name):
+            return what.id
+        if isinstance(what, ast.Attribute):
+            v = _Walker._get_name(what.value)
+            return None if v is None else f"{v}.{what.attr}"
+        return None
+
+    def _check_expression(self, expression: ast.expr) -> None:
+        if isinstance(expression, ast.Call):
+            func = _Walker._get_name(expression.func)
+            if func is not None:
+                func = self.imports.get(func, func)
+                if "." in func:
+                    module, module_func = func.rsplit(".", 1)
+                    if module in self.imports:
+                        func = f"{self.imports[module]}.{module_func}"
+                if func == "antsibull_nox.load_antsibull_nox_toml":
+                    self.has_config_load = True
+
+    def _walk(self, statements: list[ast.stmt]) -> None:
+        for statement in statements:
+            # Handle imports
+            if isinstance(statement, ast.Import):
+                for alias in statement.names:
+                    if _is_antsibull_nox_module(alias.name):
+                        self.imports[alias.asname or alias.name] = alias.name
+            if isinstance(statement, ast.ImportFrom):
+                if statement.level == 0 and _is_antsibull_nox_module(
+                    statement.module or ""
+                ):
+                    for alias in statement.names:
+                        self.imports[alias.asname or alias.name] = (
+                            f"{statement.module}.{alias.name}"
+                        )
+            # Handle try block
+            if isinstance(statement, ast.Try):
+                self._walk(statement.body)
+            # Handle expressions
+            if isinstance(statement, ast.Expr):
+                self._check_expression(statement.value)
+
+    def walk(self, module: ast.Module) -> list[str]:
+        """
+        Walk the noxfile's module and return a list of errors.
+        """
+        self._walk(module.body)
+        errors = []
+        if not self.imports:
+            errors.append(f"{self.path}: Found no antsibull_nox import")
+        if not self.has_config_load:
+            errors.append(
+                f"{self.path}: Found no call to antsibull_nox.load_antsibull_nox_toml()"
+            )
+        return errors
+
+
+def lint_noxfile() -> list[str]:
+    """
+    Do basic validation for noxfile.py. Return a list of errors.
+    """
+    path = "noxfile.py"
+    try:
+        with open(path, "rt", encoding="utf-8") as f:
+            root = ast.parse(f.read(), filename=path)
+    except FileNotFoundError:
+        return [f"{path}: File does not exist"]
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        return [f"{path}:Error while parsing Python code: {exc}"]
+
+    walker = _Walker(path)
+    return walker.walk(root)
 
 
 def lint_config() -> list[str]:
@@ -16,6 +103,7 @@ def lint_config() -> list[str]:
     Lint antsibull-nox config file.
     """
     errors = lint_config_toml()
+    errors.extend(lint_noxfile())
     return sorted(errors)
 
 

--- a/src/antsibull_nox/sessions/lint.py
+++ b/src/antsibull_nox/sessions/lint.py
@@ -497,6 +497,11 @@ def add_config_lint(
 
     def antsibull_nox_config(session: nox.Session) -> None:
         if run_antsibullnox_config_lint:
+            run_bare_script(
+                session,
+                "antsibull-nox-lint-config",
+            )
+
             session.run("antsibull-nox", "lint-config")
 
     antsibull_nox_config.__doc__ = "Lint antsibull-nox config"

--- a/src/antsibull_nox/sessions/lint.py
+++ b/src/antsibull_nox/sessions/lint.py
@@ -51,6 +51,7 @@ def add_lint(
     has_codeqa: bool,
     has_yamllint: bool,
     has_typing: bool,
+    has_config_lint: bool,
 ) -> None:
     """
     Add nox meta session for linting.
@@ -68,6 +69,8 @@ def add_lint(
         dependent_sessions.append("yamllint")
     if has_typing:
         dependent_sessions.append("typing")
+    if has_config_lint:
+        dependent_sessions.append("antsibull-nox-config")
 
     lint.__doc__ = compose_description(
         prefix={
@@ -79,6 +82,7 @@ def add_lint(
             "codeqa": has_codeqa,
             "yamllint": has_yamllint,
             "typing": has_typing,
+            "antsibull-nox-config": has_config_lint,
         },
     )
     nox.session(
@@ -483,6 +487,24 @@ def add_typing(
     nox.session(name="typing", default=False)(typing)
 
 
+def add_config_lint(
+    *,
+    run_antsibullnox_config_lint: bool,
+):
+    """
+    Add nox session for antsibull-nox config linting.
+    """
+
+    def antsibull_nox_config(session: nox.Session) -> None:
+        if run_antsibullnox_config_lint:
+            session.run("antsibull-nox", "lint-config")
+
+    antsibull_nox_config.__doc__ = "Lint antsibull-nox config"
+    nox.session(name="antsibull-nox-config", python=False, default=False)(
+        antsibull_nox_config
+    )
+
+
 def add_lint_sessions(
     *,
     make_lint_default: bool = True,
@@ -519,6 +541,8 @@ def add_lint_sessions(
     mypy_package: str = "mypy",
     mypy_ansible_core_package: str | None = "ansible-core",
     mypy_extra_deps: list[str] | None = None,
+    # antsibull-nox config lint:
+    run_antsibullnox_config_lint: bool = True,
 ) -> None:
     """
     Add nox sessions for linting.
@@ -527,12 +551,14 @@ def add_lint_sessions(
     has_codeqa = run_flake8 or run_pylint
     has_yamllint = run_yamllint
     has_typing = run_mypy
+    has_config_lint = run_antsibullnox_config_lint
 
     add_lint(
         has_formatters=has_formatters,
         has_codeqa=has_codeqa,
         has_yamllint=has_yamllint,
         has_typing=has_typing,
+        has_config_lint=has_config_lint,
         make_lint_default=make_lint_default,
     )
 
@@ -579,6 +605,11 @@ def add_lint_sessions(
             mypy_package=mypy_package,
             mypy_ansible_core_package=mypy_ansible_core_package,
             mypy_extra_deps=mypy_extra_deps or [],
+        )
+
+    if has_config_lint:
+        add_config_lint(
+            run_antsibullnox_config_lint=run_antsibullnox_config_lint,
         )
 
 


### PR DESCRIPTION
Both as a CLI (which can also print nicer errors if the config file cannot be loaded) and a subsession of `lint`.