### PR TITLE
Forgot extra_code_files when run_black_modules=false

### DIFF
--- a/changelogs/fragments/59-extra-code-black.yml
+++ b/changelogs/fragments/59-extra-code-black.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Make sure that ``extra_code_files`` is considered for ``black`` when ``run_black_modules=false`` (https://github.com/ansible-community/antsibull-nox/pull/59)."

--- a/src/antsibull_nox/sessions/lint.py
+++ b/src/antsibull_nox/sessions/lint.py
@@ -151,11 +151,15 @@ def add_formatters(
             )
             return
         if run_black:
-            paths = filter_paths(
-                CODE_FILES,
-                remove=MODULE_PATHS,
-                extensions=[".py"],
-            ) + ["noxfile.py"]
+            paths = (
+                filter_paths(
+                    CODE_FILES,
+                    remove=MODULE_PATHS,
+                    extensions=[".py"],
+                )
+                + ["noxfile.py"]
+                + extra_code_files
+            )
             execute_black_for(session, paths)
         if run_black_modules:
             paths = filter_paths(


### PR DESCRIPTION
This caused `update-docs-fragments.py` not being reformatted with black in community.dns.