### PR TITLE
Ignore special RETURN values

### DIFF
--- a/changelogs/fragments/68-yamllint-return.yml
+++ b/changelogs/fragments/68-yamllint-return.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "The yamllint session now ignores ``RETURN`` documentation with values ``#`` and `` # `` (https://github.com/ansible-community/antsibull-nox/pull/68)."

--- a/src/antsibull_nox/data/plugin-yamllint.py
+++ b/src/antsibull_nox/data/plugin-yamllint.py
@@ -128,6 +128,12 @@ def process_python_file(
             row_offset = child.value.lineno - 1
             col_offset = child.value.col_offset - 1
 
+            # Handle special values
+            if data in ("#", " # ") and section == "RETURN":
+                # Not skipping it here could result in all kind of linting errors,
+                # like no document start, or trailing space.
+                continue
+
             # If the string start with optional whitespace + linebreak, skip that line
             idx = data.find("\n")
             if idx >= 0 and (idx == 0 or data[:idx].isspace()):


### PR DESCRIPTION
Right now `RETURN = """ # """` causes YAML linting errors since there's a trailing space in ` # `. Also if you configure that plugin docs should start with a `---`, it will complain about `#` and ` # `. So we handle these two contents specially and simply not run them through yamllint.