### PR TITLE
yamllint: use wrapper script to avoid showing all YAML files in command line, and loading user's global config

### DIFF
--- a/changelogs/fragments/68-yamllint-return.yml
+++ b/changelogs/fragments/68-yamllint-return.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - "The yamllint session now ignores ``RETURN`` documentation with values ``#`` and `` # `` (https://github.com/ansible-community/antsibull-nox/pull/68)."

--- a/changelogs/fragments/71-yamllint-return.yml
+++ b/changelogs/fragments/71-yamllint-return.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "The yamllint session now ignores ``RETURN`` documentation with values ``#`` and `` # `` (https://github.com/ansible-community/antsibull-nox/pull/71)."

--- a/changelogs/fragments/72-yamllint-config.yml
+++ b/changelogs/fragments/72-yamllint-config.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "Adjust yamllint test to no longer use the user's global config, but only the project's config (https://github.com/ansible-community/antsibull-nox/pull/72)."
+minor_changes:
+  - "The yamllint test no longer shows all filenames in the command line (https://github.com/ansible-community/antsibull-nox/pull/72)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ module = [
     "pytest",
     "semantic_version",
     "yamllint",
+    "yamllint.cli",
     "yamllint.config",
     "yamllint.linter",
 ]

--- a/src/antsibull_nox/data/file-yamllint.py
+++ b/src/antsibull_nox/data/file-yamllint.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2025, Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt
+# or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Make sure all plugin and module documentation adheres to yamllint."""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+import traceback
+import typing as t
+
+from antsibull_nox_data_util import setup  # type: ignore
+from yamllint import linter
+from yamllint.cli import find_project_config_filepath
+from yamllint.config import YamlLintConfig
+from yamllint.linter import PROBLEM_LEVELS
+
+REPORT_LEVELS: set[PROBLEM_LEVELS] = {
+    "warning",
+    "error",
+}
+
+
+def lint(
+    *,
+    errors: list[dict[str, t.Any]],
+    path: str,
+    data: str,
+    config: YamlLintConfig,
+) -> None:
+    try:
+        problems = linter.run(
+            io.StringIO(data),
+            config,
+            path,
+        )
+        for problem in problems:
+            if problem.level not in REPORT_LEVELS:
+                continue
+            msg = f"{problem.level}: {problem.desc}"
+            if problem.rule:
+                msg += f"  ({problem.rule})"
+            errors.append(
+                {
+                    "path": path,
+                    "line": problem.line,
+                    "col": problem.column,
+                    "message": msg,
+                }
+            )
+    except Exception as exc:
+        error = str(exc).replace("\n", " / ")
+        errors.append(
+            {
+                "path": path,
+                "line": 1,
+                "col": 1,
+                "message": (
+                    f"Internal error while linting YAML: exception {type(exc)}:"
+                    f" {error}; traceback: {traceback.format_exc()!r}"
+                ),
+            }
+        )
+
+
+def process_yaml_file(
+    errors: list[dict[str, t.Any]],
+    path: str,
+    config: YamlLintConfig,
+) -> None:
+    try:
+        with open(path, "rt", encoding="utf-8") as stream:
+            data = stream.read()
+    except Exception as exc:
+        errors.append(
+            {
+                "path": path,
+                "line": 1,
+                "col": 1,
+                "message": (
+                    f"Error while parsing Python code: exception {type(exc)}:"
+                    f" {exc}; traceback: {traceback.format_exc()!r}"
+                ),
+            }
+        )
+        return
+
+    lint(
+        errors=errors,
+        path=path,
+        data=data,
+        config=config,
+    )
+
+
+def main() -> int:
+    """Main entry point."""
+    paths, extra_data = setup()
+    config: str | None = extra_data.get("config")
+
+    if config is None:
+        config = find_project_config_filepath()
+
+    if config:
+        yamllint_config = YamlLintConfig(file=config)
+    else:
+        yamllint_config = YamlLintConfig(content="extends: default")
+
+    errors: list[dict[str, t.Any]] = []
+    for path in paths:
+        if not os.path.isfile(path):
+            continue
+        process_yaml_file(errors, path, yamllint_config)
+
+    errors.sort(
+        key=lambda error: (error["path"], error["line"], error["col"], error["message"])
+    )
+    for error in errors:
+        prefix = f"{error['path']}:{error['line']}:{error['col']}: "
+        msg = error["message"]
+        if "note" in error:
+            msg = f"{msg}\nNote: {error['note']}"
+        for i, line in enumerate(msg.splitlines()):
+            print(f"{prefix}{line}")
+            if i == 0:
+                prefix = " " * len(prefix)
+
+    return len(errors) > 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/antsibull_nox/data/plugin-yamllint.py
+++ b/src/antsibull_nox/data/plugin-yamllint.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2024, Felix Fontein <felix@fontein.de>
+# Copyright (c) 2025, Felix Fontein <felix@fontein.de>
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt
 # or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later

--- a/src/antsibull_nox/sessions/lint.py
+++ b/src/antsibull_nox/sessions/lint.py
@@ -335,29 +335,22 @@ def add_yamllint(
     def execute_yamllint(session: nox.Session) -> None:
         # Run yamllint
         all_files = list_all_files()
-        cwd = Path.cwd()
         all_yaml_filenames = [
-            str(file.relative_to(cwd))
-            for file in all_files
-            if file.name.lower().endswith((".yml", ".yaml"))
+            file for file in all_files if file.name.lower().endswith((".yml", ".yaml"))
         ]
         if not all_yaml_filenames:
             session.warn("Skipping yamllint since no YAML file was found...")
             return
 
-        command = ["yamllint"]
-        if yamllint_config is not None:
-            command.extend(
-                [
-                    "-c",
-                    str(yamllint_config),
-                ]
-            )
-        command.append("--strict")
-        command.append("--")
-        command.extend(all_yaml_filenames)
-        command.extend(session.posargs)
-        session.run(*command)
+        run_bare_script(
+            session,
+            "file-yamllint",
+            use_session_python=True,
+            files=all_yaml_filenames,
+            extra_data={
+                "config": to_str(yamllint_config),
+            },
+        )
 
     def execute_plugin_yamllint(session: nox.Session) -> None:
         # Run yamllint


### PR DESCRIPTION
This is a breaking change in the sense that it no longer uses the user's global yamllint config, if no explicit config file is passed. I've classified this as a bugfix though since that's not helpful behavior for a CI tool.