### PR TITLE
ee-check: add runtime_extra_vars option

### DIFF
--- a/changelogs/fragments/16-ee-check.yml
+++ b/changelogs/fragments/16-ee-check.yml
@@ -1,6 +1,7 @@
 minor_changes:
   - "Add an ``ee-check`` session that allows test builds of execution environments
      (https://github.com/ansible-community/antsibull-nox/issues/16, https://github.com/ansible-community/antsibull-nox/pull/69,
-     https://github.com/ansible-community/antsibull-nox/pull/99, https://github.com/ansible-community/antsibull-nox/pull/100)."
+     https://github.com/ansible-community/antsibull-nox/pull/99, https://github.com/ansible-community/antsibull-nox/pull/100,
+     https://github.com/ansible-community/antsibull-nox/pull/101)."
   - "When using the reusable GHA workflow, execution environment tests are automatically added to the matrix
      (https://github.com/ansible-community/antsibull-nox/issues/16, https://github.com/ansible-community/antsibull-nox/pull/99)."

--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -1252,6 +1252,10 @@ The `[sessions.ee_check]` section is optional and accepts the following options:
       when the playbooks are executed.
       This will be passed through `--container-options` to `ansible-navigator`.
 
+    * `runtime_extra_vars: dict[str, str]` (default `{}`):
+      Specify extra variables that will be set when the playbooks are executed.
+      This will be passed through `-e` to `ansible-navigator`.
+
 For more information about these options, see the [Execution environment definition](https://ansible.readthedocs.io/projects/builder/en/latest/definition/) documentation for Ansible Builder.
 
 !!! note

--- a/src/antsibull_nox/config.py
+++ b/src/antsibull_nox/config.py
@@ -200,6 +200,7 @@ class ExecutionEnvironmentConfig(_BaseModel):
     test_playbooks: list[str]
     runtime_environment: dict[str, str] = {}
     runtime_container_options: list[str] = []
+    runtime_extra_vars: dict[str, str] = {}
 
     def to_execution_environment_config(self) -> dict[str, t.Any]:
         """

--- a/src/antsibull_nox/interpret_config.py
+++ b/src/antsibull_nox/interpret_config.py
@@ -320,6 +320,7 @@ def _add_sessions(sessions: Sessions) -> None:
                     test_playbooks=ee_config.test_playbooks,
                     runtime_environment=ee_config.runtime_environment,
                     runtime_container_options=ee_config.runtime_container_options,
+                    runtime_extra_vars=ee_config.runtime_extra_vars,
                 )
             )
 


### PR DESCRIPTION
This is needed for https://github.com/ansible-collections/community.crypto/pull/942.

Also adjusts the CLI argument order, which hopefully fixes https://github.com/ansible-collections/community.docker/pull/1100.