### PR TITLE
Handle non-JSON pylint output gracefully

### DIFF
--- a/changelogs/fragments/140-pylint.yml
+++ b/changelogs/fragments/140-pylint.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - If pylint's output is not valid JSON, show output instead of crashing (https://github.com/ansible-community/antsibull-nox/pull/140).

--- a/src/antsibull_nox/sessions/lint.py
+++ b/src/antsibull_nox/sessions/lint.py
@@ -447,16 +447,22 @@ def process_pylint_errors(
     """
     Process errors reported by pylint in 'json2' format.
     """
-    data = json.loads(output)
     found_error = False
-    if data["messages"]:
-        for message in data["messages"]:
-            path = os.path.relpath(
-                message["absolutePath"], prepared_collections.current_path
-            )
-            prefix = f"{path}:{message['line']}:{message['column']}: [{message['messageId']}]"
-            print(f"{prefix} {message['message']} [{message['symbol']}]")
-            found_error = True
+    try:
+        data = json.loads(output)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        session.warn(f"Cannot parse pylint output: {exc}")
+        print(output)
+        found_error = True
+    else:
+        if data["messages"]:
+            for message in data["messages"]:
+                path = os.path.relpath(
+                    message["absolutePath"], prepared_collections.current_path
+                )
+                prefix = f"{path}:{message['line']}:{message['column']}: [{message['messageId']}]"
+                print(f"{prefix} {message['message']} [{message['symbol']}]")
+                found_error = True
     if found_error:
         session.error("Pylint failed")
 


### PR DESCRIPTION
Right now, antsibull-nox simply crashes and shows a stack trace, and doesn't show pylint's output.