### PR TITLE
Ansible 2.9: do not use venv if ansible-galaxy collection doesn't know about download

### DIFF
--- a/changelogs/fragments/155-venv.yml
+++ b/changelogs/fragments/155-venv.yml
@@ -1,3 +1,4 @@
 minor_changes:
   - "When running ansible-galaxy to list, download, or install collections, look in the current session's venv first
-     (https://github.com/ansible-community/antsibull-nox/pull/155, https://github.com/ansible-community/antsibull-nox/pull/157, https://github.com/ansible-community/antsibull-nox/pull/158)."
+     (https://github.com/ansible-community/antsibull-nox/pull/155, https://github.com/ansible-community/antsibull-nox/pull/157,
+     https://github.com/ansible-community/antsibull-nox/pull/158, https://github.com/ansible-community/antsibull-nox/pull/160)."


### PR DESCRIPTION
Follow-up to #155, #157, and #158.

Ref: https://github.com/ansible-collections/community.library_inventory_filtering/actions/runs/20186945963/job/57967080369