### PR TITLE
Run ansible-test env ahead of ansible-test

### DIFF
--- a/changelogs/fragments/199-ansible-test.yml
+++ b/changelogs/fragments/199-ansible-test.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - "Run ``ansible-test env`` before running ansible-test tests.
+     Also allow to supply ``--timeout`` parameter by setting ``ANTSIBULL_NOX_TIMEOUT`` environment variable;
+     this is for use in CI systems such as Azure Pipelines
+     (https://github.com/ansible-community/antsibull-nox/pull/199)."

--- a/src/antsibull_nox/sessions/ansible_test.py
+++ b/src/antsibull_nox/sessions/ansible_test.py
@@ -161,6 +161,18 @@ def add_ansible_test_session(
             if callback_before:
                 callback_before()
 
+            env_command = [
+                "ansible-test",
+                "env",
+                "--dump",
+                "--show",
+                "-v",
+            ] + get_ansible_test_color_flag(session)
+            timeout = os.environ.get("ANTSIBULL_NOX_TIMEOUT")
+            if timeout:
+                env_command.extend(["--timeout", timeout])
+            session.run(*env_command, env=get_ansible_test_env())
+
             command = ["ansible-test"]
             for param in ansible_test_params:
                 if isinstance(param, _ColorFlagType):


### PR DESCRIPTION
Also allow to pass timeout. This is similar to what the AZP collection tests do (see https://github.com/ansible-collections/community.general/blob/main/tests/utils/shippable/shippable.sh#L222).