### PR TITLE
Support --retry-on-error and --continue-on-error for ansible-test integration

### DIFF
--- a/changelogs/fragments/201-interation-test-settings.yml
+++ b/changelogs/fragments/201-interation-test-settings.yml
@@ -1,3 +1,5 @@
 minor_changes:
   - "Allow to configure whether ``ansible-test integration`` is passed the ``--retry-on-error`` flag
      (https://github.com/ansible-community/antsibull-nox/pull/201)."
+  - "Allow to configure whether ``ansible-test integration`` is passed the ``--continue-on-error`` flag
+     (https://github.com/ansible-community/antsibull-nox/pull/201)."

--- a/changelogs/fragments/201-interation-test-settings.yml
+++ b/changelogs/fragments/201-interation-test-settings.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "Allow to configure whether ``ansible-test integration`` is passed the ``--retry-on-error`` flag
+     (https://github.com/ansible-community/antsibull-nox/pull/201)."

--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -1321,6 +1321,12 @@ By default,
   This causes ansible-test to re-run a failed integration test with higher verbosity settings.
   Only if the second invocation also fails, the complete run fails.
 
+* `continue_on_error: "never" | "always" | "in-ci"` (default `"never"`):
+  If set to `"always"`, or set to `"in-ci"` and antsibull-nox detects it is run in a CI environment,
+  ansible-test will be passed the `--continue-on-error` flag.
+  This causes ansible-test to continue executing the next test(s) after an integration test (finally) failed,
+  instead of terminating the execution.
+
 #### Example code
 
 This example is from `community.dns`.
@@ -1414,6 +1420,12 @@ You explicitly have to list all sessions in `antsibull-nox.toml`.
   ansible-test will be passed the `--retry-on-error` flag.
   This causes ansible-test to re-run a failed integration test with higher verbosity settings.
   Only if the second invocation also fails, the complete run fails.
+
+* `continue_on_error: "never" | "always" | "in-ci"` (default `"never"`):
+  If set to `"always"`, or set to `"in-ci"` and antsibull-nox detects it is run in a CI environment,
+  ansible-test will be passed the `--continue-on-error` flag.
+  This causes ansible-test to continue executing the next test(s) after an integration test (finally) failed,
+  instead of terminating the execution.
 
 * `tags: list[str]` (default: `[]`):
   A list of tags to add to all sessions.
@@ -1517,6 +1529,14 @@ You explicitly have to list all sessions in `antsibull-nox.toml`.
 
         If set to `None`, the group value (if applicable) or the global value of `retry_on_error` is used.
 
+    * `continue_on_error: "never" | "always" | "in-ci" | None` (default `None`):
+      If set to `"always"`, or set to `"in-ci"` and antsibull-nox detects it is run in a CI environment,
+      ansible-test will be passed the `--continue-on-error` flag.
+      This causes ansible-test to continue executing the next test(s) after an integration test (finally) failed,
+      instead of terminating the execution.
+
+        If set to `None`, the group value (if applicable) or the global value of `continue_on_error` is used.
+
     * `tags: list[str]` (default: `[]`):
       A list of tags to add to all sessions for this session template.
       These tags can be used when filtering sessions for CI matrix generation.
@@ -1579,6 +1599,14 @@ You explicitly have to list all sessions in `antsibull-nox.toml`.
       Only if the second invocation also fails, the complete run fails.
 
         If set to `None`, the global value of `retry_on_error` is used.
+
+    * `continue_on_error: "never" | "always" | "in-ci" | None` (default `None`):
+      If set to `"always"`, or set to `"in-ci"` and antsibull-nox detects it is run in a CI environment,
+      ansible-test will be passed the `--continue-on-error` flag.
+      This causes ansible-test to continue executing the next test(s) after an integration test (finally) failed,
+      instead of terminating the execution.
+
+        If set to `None`, the global value of `continue_on_error` is used.
 
     * `tags: list[str]` (default: `[]`):
       A list of tags to add to all sessions for this group template.

--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -1315,6 +1315,12 @@ By default,
     * `value_template: str | None` (default `None`):
       If set, show this value insead of the real value in templates (see further below).
 
+* `retry_on_error: "never" | "always" | "in-ci"` (default `"never"`):
+  If set to `"always"`, or set to `"in-ci"` and antsibull-nox detects it is run in a CI environment,
+  ansible-test will be passed the `--retry-on-error` flag.
+  This causes ansible-test to re-run a failed integration test with higher verbosity settings.
+  Only if the second invocation also fails, the complete run fails.
+
 #### Example code
 
 This example is from `community.dns`.
@@ -1403,6 +1409,12 @@ You explicitly have to list all sessions in `antsibull-nox.toml`.
   See below for the available variables.
   This can also be overriden for specific sessions.
 
+* `retry_on_error: "never" | "always" | "in-ci"` (default `"never"`):
+  If set to `"always"`, or set to `"in-ci"` and antsibull-nox detects it is run in a CI environment,
+  ansible-test will be passed the `--retry-on-error` flag.
+  This causes ansible-test to re-run a failed integration test with higher verbosity settings.
+  Only if the second invocation also fails, the complete run fails.
+
 * `tags: list[str]` (default: `[]`):
   A list of tags to add to all sessions.
   These tags can be used when filtering sessions for CI matrix generation.
@@ -1465,23 +1477,23 @@ You explicitly have to list all sessions in `antsibull-nox.toml`.
       Please note that branches are usually deleted upon merging,
       so you have to remove them again from your `noxfile.py` to avoid CI breaking.
 
-      ```toml
-      # To add the Data Tagging PR (https://github.com/ansible/ansible/pull/84621)
-      # to CI, we can either use the special GitHub reference refs/pull/84621/head
-      # to refer to the PR's HEAD:
-      devel_like_branch = { branch = "refs/pull/84621/head" }
+        ```toml
+        # To add the Data Tagging PR (https://github.com/ansible/ansible/pull/84621)
+        # to CI, we can either use the special GitHub reference refs/pull/84621/head
+        # to refer to the PR's HEAD:
+        devel_like_branch = { branch = "refs/pull/84621/head" }
 
-      # We can also just specify a branch as a string:
-      devel_like_branch = "refs/pull/84621/head"
+        # We can also just specify a branch as a string:
+        devel_like_branch = "refs/pull/84621/head"
 
-      # Alternatively, we can specify a GitHub repository and a branch in that
-      # repository. The Data Tagging PR is based on a branch in nitzmahone's fork
-      # of ansible/ansible:
-      devel_like_branch = { repository = "nitzmahone/ansible", branch = "data_tagging_219" }
+        # Alternatively, we can specify a GitHub repository and a branch in that
+        # repository. The Data Tagging PR is based on a branch in nitzmahone's fork
+        # of ansible/ansible:
+        devel_like_branch = { repository = "nitzmahone/ansible", branch = "data_tagging_219" }
 
-      # We can also provide a two-element list with repository name and branch:
-      devel_like_branch = ["nitzmahone/ansible", "data_tagging_219"]
-      ```
+        # We can also provide a two-element list with repository name and branch:
+        devel_like_branch = ["nitzmahone/ansible", "data_tagging_219"]
+        ```
 
     * `ansible_vars: dict[str, AnsibleValueField]` (default: `{}
       If given, will create an integration test config file which for every `key=value` pair.
@@ -1496,6 +1508,14 @@ You explicitly have to list all sessions in `antsibull-nox.toml`.
 
     * `description_template: str | None` (default: `None`)
       If given, will overwrite `[sessions.ansible_test_integration.description_template]`.
+
+    * `retry_on_error: "never" | "always" | "in-ci" | None` (default `None`):
+      If set to `"always"`, or set to `"in-ci"` and antsibull-nox detects it is run in a CI environment,
+      ansible-test will be passed the `--retry-on-error` flag.
+      This causes ansible-test to re-run a failed integration test with higher verbosity settings.
+      Only if the second invocation also fails, the complete run fails.
+
+        If set to `None`, the group value (if applicable) or the global value of `retry_on_error` is used.
 
     * `tags: list[str]` (default: `[]`):
       A list of tags to add to all sessions for this session template.
@@ -1552,6 +1572,14 @@ You explicitly have to list all sessions in `antsibull-nox.toml`.
     * `description_template: str | None` (default: `None`)
       Allows to provide a session's description template that overrides the global one `[sessions.ansible_test_integration.description_template]`.
       This can be overridden in each session template.
+    * `retry_on_error: "never" | "always" | "in-ci" | None` (default `None`):
+      If set to `"always"`, or set to `"in-ci"` and antsibull-nox detects it is run in a CI environment,
+      ansible-test will be passed the `--retry-on-error` flag.
+      This causes ansible-test to re-run a failed integration test with higher verbosity settings.
+      Only if the second invocation also fails, the complete run fails.
+
+        If set to `None`, the global value of `retry_on_error` is used.
+
     * `tags: list[str]` (default: `[]`):
       A list of tags to add to all sessions for this group template.
       These tags can be used when filtering sessions for CI matrix generation.

--- a/src/antsibull_nox/config.py
+++ b/src/antsibull_nox/config.py
@@ -148,6 +148,8 @@ _VALID_PACKAGE_TYPE_NAMES = tuple(
     p.model_fields["type"].default for p in t.get_args(PackageType)
 )
 
+NeverAlwaysInCI = t.Literal["never", "always", "in-ci"]
+
 
 def _package_name_validator(value: t.Any, *, keep_strings: bool = False) -> t.Any:
     """
@@ -652,6 +654,7 @@ class SessionAnsibleTestIntegrationWDefaultContainer(_BaseModel):
     controller_python_versions_only: bool = False
     ansible_vars_from_env_vars: dict[str, str] = {}
     ansible_vars: dict[str, AnsibleValueField] = {}
+    retry_on_error: NeverAlwaysInCI = "never"
 
     @p.model_validator(mode="after")
     def _validate_core_keys(self) -> t.Self:
@@ -688,6 +691,8 @@ class SessionAnsibleTestIntegrationSession(_BaseModel):
     session_name_template: t.Union[str, None] = None
     display_name_template: t.Union[str, None] = None
     description_template: t.Union[str, None] = None
+
+    retry_on_error: t.Optional[NeverAlwaysInCI] = None
 
     # Tags for session registration; can be used by matrix generator
     tags: list[str] = []
@@ -727,6 +732,8 @@ class SessionAnsibleTestIntegrationGroup(_BaseModel):
     display_name_template: t.Union[str, None] = None
     description_template: t.Union[str, None] = None
 
+    retry_on_error: t.Optional[NeverAlwaysInCI] = None
+
     # Tags for session registration; can be used by matrix generator
     tags: list[str] = []
 
@@ -741,6 +748,8 @@ class SessionAnsibleTestIntegration(_BaseModel):
     ansible_vars: dict[str, AnsibleValueField] = {}
     sessions: list[SessionAnsibleTestIntegrationSession] = []
     groups: list[SessionAnsibleTestIntegrationGroup] = []
+
+    retry_on_error: NeverAlwaysInCI = "never"
 
     session_name_template: str = (
         "ansible-test-integration-{target_dash}{ansible_core}"

--- a/src/antsibull_nox/config.py
+++ b/src/antsibull_nox/config.py
@@ -655,6 +655,7 @@ class SessionAnsibleTestIntegrationWDefaultContainer(_BaseModel):
     ansible_vars_from_env_vars: dict[str, str] = {}
     ansible_vars: dict[str, AnsibleValueField] = {}
     retry_on_error: NeverAlwaysInCI = "never"
+    continue_on_error: NeverAlwaysInCI = "never"
 
     @p.model_validator(mode="after")
     def _validate_core_keys(self) -> t.Self:
@@ -693,6 +694,7 @@ class SessionAnsibleTestIntegrationSession(_BaseModel):
     description_template: t.Union[str, None] = None
 
     retry_on_error: t.Optional[NeverAlwaysInCI] = None
+    continue_on_error: t.Optional[NeverAlwaysInCI] = None
 
     # Tags for session registration; can be used by matrix generator
     tags: list[str] = []
@@ -733,6 +735,7 @@ class SessionAnsibleTestIntegrationGroup(_BaseModel):
     description_template: t.Union[str, None] = None
 
     retry_on_error: t.Optional[NeverAlwaysInCI] = None
+    continue_on_error: t.Optional[NeverAlwaysInCI] = None
 
     # Tags for session registration; can be used by matrix generator
     tags: list[str] = []
@@ -750,6 +753,7 @@ class SessionAnsibleTestIntegration(_BaseModel):
     groups: list[SessionAnsibleTestIntegrationGroup] = []
 
     retry_on_error: NeverAlwaysInCI = "never"
+    continue_on_error: NeverAlwaysInCI = "never"
 
     session_name_template: str = (
         "ansible-test-integration-{target_dash}{ansible_core}"

--- a/src/antsibull_nox/interpret_config.py
+++ b/src/antsibull_nox/interpret_config.py
@@ -266,6 +266,7 @@ def _add_ansible_test_sessions(sessions: Sessions, cconfig: CollectionConfig) ->
                     k: v.to_utils_instance() for k, v in cfg.ansible_vars.items()
                 },
                 retry_on_error=cfg.retry_on_error,
+                continue_on_error=cfg.continue_on_error,
             )
         )
     if sessions.ansible_test_integration:
@@ -301,6 +302,8 @@ def _add_ansible_test_sessions(sessions: Sessions, cconfig: CollectionConfig) ->
                         or sessions.ansible_test_integration.description_template,
                         retry_on_error=session.retry_on_error
                         or sessions.ansible_test_integration.retry_on_error,
+                        continue_on_error=session.continue_on_error
+                        or sessions.ansible_test_integration.continue_on_error,
                         tags=session.tags,
                     )
                     for session in sessions.ansible_test_integration.sessions
@@ -355,6 +358,9 @@ def _add_ansible_test_sessions(sessions: Sessions, cconfig: CollectionConfig) ->
                                 retry_on_error=session.retry_on_error
                                 or group.retry_on_error
                                 or sessions.ansible_test_integration.retry_on_error,
+                                continue_on_error=session.continue_on_error
+                                or group.continue_on_error
+                                or sessions.ansible_test_integration.continue_on_error,
                                 tags=session.tags,
                             )
                             for session in group.sessions

--- a/src/antsibull_nox/interpret_config.py
+++ b/src/antsibull_nox/interpret_config.py
@@ -265,6 +265,7 @@ def _add_ansible_test_sessions(sessions: Sessions, cconfig: CollectionConfig) ->
                 ansible_vars={
                     k: v.to_utils_instance() for k, v in cfg.ansible_vars.items()
                 },
+                retry_on_error=cfg.retry_on_error,
             )
         )
     if sessions.ansible_test_integration:
@@ -298,6 +299,8 @@ def _add_ansible_test_sessions(sessions: Sessions, cconfig: CollectionConfig) ->
                         or sessions.ansible_test_integration.display_name_template,
                         description_template=session.description_template
                         or sessions.ansible_test_integration.description_template,
+                        retry_on_error=session.retry_on_error
+                        or sessions.ansible_test_integration.retry_on_error,
                         tags=session.tags,
                     )
                     for session in sessions.ansible_test_integration.sessions
@@ -349,6 +352,9 @@ def _add_ansible_test_sessions(sessions: Sessions, cconfig: CollectionConfig) ->
                                 description_template=session.description_template
                                 or group.description_template
                                 or sessions.ansible_test_integration.description_template,
+                                retry_on_error=session.retry_on_error
+                                or group.retry_on_error
+                                or sessions.ansible_test_integration.retry_on_error,
                                 tags=session.tags,
                             )
                             for session in group.sessions

--- a/src/antsibull_nox/sessions/ansible_test.py
+++ b/src/antsibull_nox/sessions/ansible_test.py
@@ -38,6 +38,7 @@ from ..python.versions import get_installed_python_versions
 from ..utils import Version
 from .collections import prepare_collections
 from .utils import (
+    IN_CI,
     normalize_session_name,
     nox_has_color,
     register,
@@ -51,6 +52,7 @@ from .utils.values import (
 
 if t.TYPE_CHECKING:
     DevelLikeBranch = tuple[str | None, str]
+    NeverAlwaysInCI = t.Literal["never", "always", "in-ci"]
 
 
 def get_ansible_test_env() -> dict[str, str]:
@@ -553,6 +555,17 @@ def _add_version_specific_interation_test_params(
         parameters.extend(["--display-traceback", "error"])
 
 
+def _is_applicable(value: NeverAlwaysInCI) -> bool:
+    return value == "always" or (value == "in-ci" and IN_CI)
+
+
+def _add_retry_on_error_params(
+    parameters: list[str | _ColorFlagType], retry_on_error: NeverAlwaysInCI
+) -> None:
+    if _is_applicable(retry_on_error):
+        parameters.append("--retry-on-error")
+
+
 def add_ansible_test_integration_sessions_default_container(
     *,
     include_devel: bool = False,
@@ -568,6 +581,7 @@ def add_ansible_test_integration_sessions_default_container(
     min_python_version: MinPythonVersion | None = None,
     ansible_vars_from_env_vars: dict[str, str] | None = None,
     ansible_vars: dict[str, AnsibleValue] | None = None,
+    retry_on_error: NeverAlwaysInCI = "never",
     default: bool = False,
 ) -> list[str]:
     """
@@ -676,6 +690,7 @@ def add_ansible_test_integration_sessions_default_container(
             _add_version_specific_interation_test_params(
                 parameters, ansible_core_version
             )
+            _add_retry_on_error_params(parameters, retry_on_error)
             add_ansible_test_session(
                 name=name,
                 description=description,
@@ -773,6 +788,7 @@ class AnsibleTestIntegrationSessionTemplate:
     session_name_template: str
     display_name_template: str
     description_template: str
+    retry_on_error: NeverAlwaysInCI
     tags: list[str]
 
 
@@ -811,6 +827,7 @@ class AnsibleTestIntegrationSession:
     session_name: str
     display_name: str
     description: str
+    retry_on_error: NeverAlwaysInCI
     tags: list[str]
 
     def get_ansible_vars_callback(self) -> t.Callable[[], None] | None:
@@ -948,6 +965,7 @@ def _template_session(
             ),
             display_name=tmpl(session_template.display_name_template),
             description=tmpl(session_template.description_template),
+            retry_on_error=session_template.retry_on_error,
             tags=tags_list,
         )
 
@@ -1029,6 +1047,7 @@ def add_ansible_test_integration_sessions(
             "-v",
         ]
         _add_version_specific_interation_test_params(cmd, session.ansible_core)
+        _add_retry_on_error_params(cmd, session.retry_on_error)
         if session.docker:
             cmd.extend(
                 [

--- a/src/antsibull_nox/sessions/ansible_test.py
+++ b/src/antsibull_nox/sessions/ansible_test.py
@@ -566,6 +566,13 @@ def _add_retry_on_error_params(
         parameters.append("--retry-on-error")
 
 
+def _add_continue_on_error_params(
+    parameters: list[str | _ColorFlagType], continue_on_error: NeverAlwaysInCI
+) -> None:
+    if _is_applicable(continue_on_error):
+        parameters.append("--continue-on-error")
+
+
 def add_ansible_test_integration_sessions_default_container(
     *,
     include_devel: bool = False,
@@ -582,6 +589,7 @@ def add_ansible_test_integration_sessions_default_container(
     ansible_vars_from_env_vars: dict[str, str] | None = None,
     ansible_vars: dict[str, AnsibleValue] | None = None,
     retry_on_error: NeverAlwaysInCI = "never",
+    continue_on_error: NeverAlwaysInCI = "never",
     default: bool = False,
 ) -> list[str]:
     """
@@ -691,6 +699,7 @@ def add_ansible_test_integration_sessions_default_container(
                 parameters, ansible_core_version
             )
             _add_retry_on_error_params(parameters, retry_on_error)
+            _add_continue_on_error_params(parameters, continue_on_error)
             add_ansible_test_session(
                 name=name,
                 description=description,
@@ -789,6 +798,7 @@ class AnsibleTestIntegrationSessionTemplate:
     display_name_template: str
     description_template: str
     retry_on_error: NeverAlwaysInCI
+    continue_on_error: NeverAlwaysInCI
     tags: list[str]
 
 
@@ -828,6 +838,7 @@ class AnsibleTestIntegrationSession:
     display_name: str
     description: str
     retry_on_error: NeverAlwaysInCI
+    continue_on_error: NeverAlwaysInCI
     tags: list[str]
 
     def get_ansible_vars_callback(self) -> t.Callable[[], None] | None:
@@ -966,6 +977,7 @@ def _template_session(
             display_name=tmpl(session_template.display_name_template),
             description=tmpl(session_template.description_template),
             retry_on_error=session_template.retry_on_error,
+            continue_on_error=session_template.continue_on_error,
             tags=tags_list,
         )
 
@@ -1048,6 +1060,7 @@ def add_ansible_test_integration_sessions(
         ]
         _add_version_specific_interation_test_params(cmd, session.ansible_core)
         _add_retry_on_error_params(cmd, session.retry_on_error)
+        _add_continue_on_error_params(cmd, session.continue_on_error)
         if session.docker:
             cmd.extend(
                 [


### PR DESCRIPTION
Allows to add these options always, never, or when executed in CI.

This is useful if integration tests sometimes fail. It can also hide errors, though, like integration test dependencies not installed correctly for filter plugins. (See for example https://github.com/ansible-collections/community.crypto/pull/1018#issuecomment-4570728271.)
