### PR TITLE
Allow to always copy repo structure before invoking 'ansible-test env'

### DIFF
--- a/changelogs/fragments/202-repo-structure.yml
+++ b/changelogs/fragments/202-repo-structure.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - "Allow to always copy the repository structure before invoking ``ansible-test env``
+     by setting the ``ANTSIBULL_NOX_ALWAYS_COPY_REPO_STRUCTURE`` environment variable to ``true``.
+     This is mainly needed to work around a bug in ``ansible-test env`` in conjunction with AZP
+     (https://github.com/ansible-community/antsibull-nox/pull/202)."

--- a/src/antsibull_nox/sessions/ansible_test.py
+++ b/src/antsibull_nox/sessions/ansible_test.py
@@ -147,13 +147,18 @@ def add_ansible_test_session(
                         base_branch,
                     ]
 
+        always_copy_repo_structure = (
+            os.environ.get("ANTSIBULL_NOX_ALWAYS_COPY_REPO_STRUCTURE") == "true"
+        )
+
         prepared_collections = prepare_collections(
             session,
             ansible_core_version=parsed_ansible_core_version,
             install_in_site_packages=False,
             extra_deps_files=extra_deps_files,
             install_out_of_tree=True,
-            copy_repo_structure=change_detection_args is not None,
+            copy_repo_structure=change_detection_args is not None
+            or always_copy_repo_structure,
         )
         if not prepared_collections:
             session.warn("Skipping ansible-test...")


### PR DESCRIPTION
Needed to work around https://github.com/ansible/ansible/issues/87052 in https://github.com/ansible-collections/community.docker/pull/1267 and https://github.com/ansible-collections/community.crypto/pull/1024.