### PR TITLE
Allow to split up unit test sessions by Python version

### DIFF
--- a/changelogs/fragments/209-units.yml
+++ b/changelogs/fragments/209-units.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - Allow to split up unit test sessions per Python version,
+    and allow finer control which Python versions for every ansible-core version to control a unit test session for
+    (https://github.com/ansible-community/antsibull-nox/pull/209).

--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -1179,6 +1179,40 @@ The function supports the following parameters:
   The list elements can be strings of the form `"devel"`, `"milestone"`,
   and `"x.y"` where `x` and `y` are integers that specify a minor ansible-core x.y release.
 
+* `split_by_python_version: bool` (default: `false`):
+  If set to `false`, there will be one session per ansible-core version.
+  If set to `true`, every ansible-core and Python version combination will get its own session.
+  For collections with large unit test suites it can make sense to set this to `true`.
+
+* `core_python_versions: dict[AnsibleCoreVersion | str, list[Version]]` (default `{}`):
+  Restrict the number of Python versions per ansible-core release.
+  An empty list means that the ansible-core version will be skipped completely.
+  If no restrictions are provided, all Python versions supported by this version of ansible-core are used;
+  see `controller_python_versions_only` below for more details.
+
+    Note that this setting can only be set to a non-empty value if `split_by_python_version=true`.
+
+    Note that this setting is a new section `[sessions.ansible_test_units.core_python_versions]`.
+    The keys can be strings `"devel"`, `"milestone"`, and `"x.y"`, where ansible-core x.y is a minor ansible-core release;
+    if `add_devel_like_branches`, the branch names appearing in `add_devel_like_branches` can also be specified.
+    The values can be strings `"x.y"`, where Python x.y is a minor Python release.
+
+    If this is set, `min_python_version` is ignored.
+
+* `controller_python_versions_only: bool` (default `false`):
+  For ansible-core versions where `core_python_versions` does not provide a list of Python versions,
+  usually all Python versions supported on the remote side are used.
+  If this is set to `true`, only all Python versions uspported on the controller side are used.
+
+    Note that this setting can only be set to `true` if `split_by_python_version=true`.
+    If you want to restrict unit tests to controller Python versions if `split_by_python_version=false`,
+    consider using an ansible-test configuration file.
+
+    When set to `true`,
+    this behaves the same as when `min_python_version` is set to `"controller"`,
+    or when `min_python_version` is set to `"ansible-test-config"`
+    and `tests/config.yml` has `modules.python_requires` set to `"controller"`.
+
 #### Example code
 
 This example is from `community.dns`.

--- a/src/antsibull_nox/azp.py
+++ b/src/antsibull_nox/azp.py
@@ -22,6 +22,11 @@ from collections.abc import Iterable, Mapping
 from pathlib import Path
 
 from .ansible import AnsibleCoreVersion, parse_ansible_core_version
+from .config import (
+    CONFIG_FILENAME,
+    load_config_from_toml,
+)
+from .lint_config import NOXFILE_PY
 from .utils import Version
 
 _YAML_NO_NEED_TO_ESCAPE = re.compile(r"^[a-zA-Z0-9_ .,;/()+-]+$")
@@ -134,7 +139,9 @@ def _ansible_core_name(version: AnsibleCoreVersion | None = None) -> str:
     return "ansible-core"
 
 
-def _get_title(session: dict[str, t.Any], *, with_ansible_core_version: bool) -> str:
+def _get_title(
+    session: dict[str, t.Any], *, with_ansible_core_version: bool, convert_py: bool
+) -> str:
     display_name = session.get("display-name")
     if display_name:
         if with_ansible_core_version:
@@ -145,12 +152,17 @@ def _get_title(session: dict[str, t.Any], *, with_ansible_core_version: bool) ->
             display_name = display_name.replace("Ⓐ", f"{ansible_core_name} ")
         else:
             display_name = _ANSIBLE_CORE_VERSION.sub("", display_name).lstrip(" +/,")
+        if convert_py:
+            display_name = display_name.replace("py", "Python ")
         display_name = display_name.replace("+", " + ")
     return display_name or session["name"]
 
 
 def _convert_sessions(
-    sessions: list[dict[str, t.Any]], *, with_ansible_core_version: bool
+    sessions: list[dict[str, t.Any]],
+    *,
+    with_ansible_core_version: bool,
+    convert_py: bool = False,
 ) -> list[_Session]:
     result = []
     for session in sessions:
@@ -158,14 +170,102 @@ def _convert_sessions(
             _Session(
                 name=session["name"],
                 title=_get_title(
-                    session, with_ansible_core_version=with_ansible_core_version
+                    session,
+                    with_ansible_core_version=with_ansible_core_version,
+                    convert_py=convert_py,
                 ),
             )
         )
     return result
 
 
-def _create_groups(data: dict[str, list[dict[str, t.Any]]]) -> list[_Group]:
+def _create_unit_groups(
+    data: dict[str, list[dict[str, t.Any]]], *, split_up_unit_tests: bool
+) -> list[_Group]:
+    if "units" not in data:
+        return []
+    if not split_up_unit_tests:
+        return [
+            _Group(
+                name="units",
+                title="Unit tests",
+                dependencies=[],
+                sessions=_convert_sessions(
+                    data["units"], with_ansible_core_version=True
+                ),
+            )
+        ]
+
+    unit_sessions: dict[str, list[dict[str, t.Any]]] = {}
+    for session in data["units"]:
+        ansible_core: str | None = session.get("ansible-core")
+        if ansible_core is None:
+            raise ValueError("Found unit test session without ansible-core information")
+        unit_session_list = unit_sessions.get(ansible_core)
+        if unit_session_list is None:
+            unit_session_list = []
+            unit_sessions[ansible_core] = unit_session_list
+        unit_session_list.append(session)
+    result = []
+    for ansible_core, sessions in unit_sessions.items():
+        result.append(
+            _Group(
+                name=f"units_{ansible_core.replace('-', '_').replace('.', '_')}",
+                title=f"Units {ansible_core}",
+                dependencies=[],
+                sessions=_convert_sessions(
+                    sessions, with_ansible_core_version=False, convert_py=True
+                ),
+            )
+        )
+    return result
+
+
+def _create_integration_groups(data: dict[str, list[dict[str, t.Any]]]) -> list[_Group]:
+    if "integration" not in data:
+        return []
+    int_sessions: dict[
+        tuple[t.Literal["docker", "remote", "other"], str], list[dict[str, t.Any]]
+    ] = {}
+    for session in data["integration"]:
+        ansible_core: str | None = session.get("ansible-core")
+        if ansible_core is None:
+            raise ValueError(
+                "Found integration test session without ansible-core information"
+            )
+        tags: list[str] = session.get("tags") or []
+        is_docker = "docker" in tags
+        is_remote = "remote" in tags
+        key: tuple[t.Literal["docker", "remote", "other"], str] = (
+            "remote" if is_remote else "docker" if is_docker else "other",
+            ansible_core,
+        )
+        int_session_list = int_sessions.get(key)
+        if int_session_list is None:
+            int_session_list = []
+            int_sessions[key] = int_session_list
+        int_session_list.append(session)
+    result = []
+    for what in sorted({w for w, _ in int_sessions}):
+        for (w, ansible_core), sessions in int_sessions.items():
+            if what != w:
+                continue
+            result.append(
+                _Group(
+                    name=f"{what}_{ansible_core.replace('-', '_').replace('.', '_')}",
+                    title=f"{what.title()} {ansible_core}",
+                    dependencies=[],
+                    sessions=_convert_sessions(
+                        sessions, with_ansible_core_version=False
+                    ),
+                )
+            )
+    return result
+
+
+def _create_groups(
+    data: dict[str, list[dict[str, t.Any]]], *, split_up_unit_tests: bool = False
+) -> list[_Group]:
     result = []
     if "sanity" in data:
         result.append(
@@ -178,53 +278,8 @@ def _create_groups(data: dict[str, list[dict[str, t.Any]]]) -> list[_Group]:
                 ),
             )
         )
-    if "units" in data:
-        result.append(
-            _Group(
-                name="units",
-                title="Unit tests",
-                dependencies=[],
-                sessions=_convert_sessions(
-                    data["units"], with_ansible_core_version=True
-                ),
-            )
-        )
-    if "integration" in data:
-        int_sessions: dict[
-            tuple[t.Literal["docker", "remote", "other"], str], list[dict[str, t.Any]]
-        ] = {}
-        for session in data["integration"]:
-            ansible_core: str | None = session.get("ansible-core")
-            if ansible_core is None:
-                raise ValueError(
-                    "Found integration test session without ansible-core information"
-                )
-            tags: list[str] = session.get("tags") or []
-            is_docker = "docker" in tags
-            is_remote = "remote" in tags
-            key: tuple[t.Literal["docker", "remote", "other"], str] = (
-                "remote" if is_remote else "docker" if is_docker else "other",
-                ansible_core,
-            )
-            int_session_list = int_sessions.get(key)
-            if int_session_list is None:
-                int_session_list = []
-                int_sessions[key] = int_session_list
-            int_session_list.append(session)
-        for what in sorted({w for w, _ in int_sessions}):
-            for (w, ansible_core), sessions in int_sessions.items():
-                if what != w:
-                    continue
-                result.append(
-                    _Group(
-                        name=f"{what}_{ansible_core.replace('-', '_').replace('.', '_')}",
-                        title=f"{what.title()} {ansible_core}",
-                        dependencies=[],
-                        sessions=_convert_sessions(
-                            sessions, with_ansible_core_version=False
-                        ),
-                    )
-                )
+    result.extend(_create_unit_groups(data, split_up_unit_tests=split_up_unit_tests))
+    result.extend(_create_integration_groups(data))
     return result
 
 
@@ -293,12 +348,18 @@ def update_azp_config(
     """
     azp_definition: Path = Path(".azure-pipelines/azure-pipelines.yml")
     for expected_file in (
-        "antsibull-nox.toml",
-        "noxfile.py",
+        CONFIG_FILENAME,
+        NOXFILE_PY,
         azp_definition,
     ):
         if not os.path.isfile(expected_file):
             raise ValueError(f"{expected_file} does not exist or is not a file")
+
+    config_path = Path(CONFIG_FILENAME)
+    config = load_config_from_toml(config_path)
+    split_up_unit_tests = False
+    if config.sessions.ansible_test_units:
+        split_up_unit_tests = config.sessions.ansible_test_units.split_by_python_version
 
     data = get_ci_matrix(
         min_ansible_core=min_ansible_core,
@@ -310,7 +371,7 @@ def update_azp_config(
     pre, old_main, post = _get_azp_definition_content(azp_definition)
     main: list[str] = []
 
-    groups = _create_groups(data)
+    groups = _create_groups(data, split_up_unit_tests=split_up_unit_tests)
     for group in groups:
         main.append(f"  - stage: {_escape_yaml(group.name)}")
         main.append(f"    displayName: {_escape_yaml(group.title)}")

--- a/src/antsibull_nox/config.py
+++ b/src/antsibull_nox/config.py
@@ -557,6 +557,23 @@ class SessionAnsibleTestUnits(_BaseModel):
     min_version: t.Optional[PVersion] = None
     max_version: t.Optional[PVersion] = None
     except_versions: list[PAnsibleCoreVersion] = []
+    split_by_python_version: bool = False
+    core_python_versions: dict[t.Union[PAnsibleCoreVersion, str], list[PVersion]] = {}
+    controller_python_versions_only: bool = False
+
+    @p.model_validator(mode="after")
+    def _validate_split_by_python_version(self) -> t.Self:
+        if not self.split_by_python_version:
+            if self.core_python_versions:
+                raise ValueError(
+                    "You cannot use core_python_versions if split_by_python_version=false"
+                )
+            if self.controller_python_versions_only:
+                raise ValueError(
+                    "You cannot set controller_python_versions_only=true"
+                    " if split_by_python_version=false"
+                )
+        return self
 
 
 class AnsibleValueExplicit(p.BaseModel):

--- a/src/antsibull_nox/interpret_config.py
+++ b/src/antsibull_nox/interpret_config.py
@@ -229,6 +229,13 @@ def _add_ansible_test_sessions(sessions: Sessions, cconfig: CollectionConfig) ->
             except_versions=_convert_except_versions(
                 sessions.ansible_test_units.except_versions
             ),
+            split_by_python_version=sessions.ansible_test_units.split_by_python_version,
+            core_python_versions=_convert_core_python_versions(
+                sessions.ansible_test_units.core_python_versions
+            ),
+            controller_python_versions_only=(
+                sessions.ansible_test_units.controller_python_versions_only
+            ),
         )
 
     # Handle integration tests

--- a/src/antsibull_nox/sessions/ansible_test.py
+++ b/src/antsibull_nox/sessions/ansible_test.py
@@ -522,14 +522,18 @@ def add_ansible_test_unit_test_session(
     ansible_core_repo_name: str | None = None,
     ansible_core_branch_name: str | None = None,
     register_extra_data: dict[str, t.Any] | None = None,
+    python_version: Version | str | None = None,
 ) -> None:
     """
     Add generic ansible-test unit test session.
     """
+    args: list[str | _ColorFlagType] = ["units", COLOR_FLAG, "-v", "--docker"]
+    if python_version is not None:
+        args.extend(["--python", str(python_version)])
     add_ansible_test_session(
         name=name,
         description=description,
-        ansible_test_params=["units", COLOR_FLAG, "-v", "--docker"],
+        ansible_test_params=args,
         extra_deps_files=["tests/unit/requirements.yml"],
         default=default,
         ansible_core_version=ansible_core_version,
@@ -543,6 +547,57 @@ def add_ansible_test_unit_test_session(
     )
 
 
+def _add_ansible_test_unit_test_session_group(
+    *,
+    name_prefix: str,
+    description_prefix: str,
+    ansible_core_version: str | AnsibleCoreVersion,
+    ansible_core_source: t.Literal["git", "pypi"] = "git",
+    ansible_core_repo_name: str | None = None,
+    ansible_core_branch_name: str | None = None,
+    python_versions: list[str | Version],
+) -> list[str]:
+    """
+    Add generic ansible-test unit test session.
+    """
+    unit_test_sessions = []
+    for python_version in python_versions:
+        name = f"{name_prefix}-{python_version}"
+        description = f"{description_prefix} with Python {python_version}"
+        ans_vers_id = ansible_core_branch_name or ansible_core_version
+        add_ansible_test_unit_test_session(
+            name=name,
+            description=description,
+            default=False,
+            ansible_core_version=ansible_core_version,
+            ansible_core_source=ansible_core_source,
+            ansible_core_repo_name=ansible_core_repo_name,
+            ansible_core_branch_name=ansible_core_branch_name,
+            register_extra_data={"display-name": f"Ⓐ{ans_vers_id}+py{python_version}"},
+            python_version=python_version,
+        )
+        unit_test_sessions.append(name)
+
+    if not unit_test_sessions:
+        return []
+
+    def run_all_unit_tests(
+        session: nox.Session,  # pylint: disable=unused-argument
+    ) -> None:
+        pass
+
+    run_all_unit_tests.__doc__ = (
+        f"Meta session for running all {name_prefix}-* sessions."
+    )
+    nox.session(
+        name=name_prefix,
+        default=False,
+        requires=unit_test_sessions,
+    )(run_all_unit_tests)
+
+    return [name_prefix]
+
+
 def add_all_ansible_test_unit_test_sessions(
     *,
     default: bool = False,
@@ -552,6 +607,11 @@ def add_all_ansible_test_unit_test_sessions(
     min_version: Version | str | None = None,
     max_version: Version | str | None = None,
     except_versions: list[AnsibleCoreVersion | str] | None = None,
+    split_by_python_version: bool = False,
+    core_python_versions: (
+        dict[str | AnsibleCoreVersion, list[str | Version]] | None
+    ) = None,
+    controller_python_versions_only: bool = False,
 ) -> None:
     """
     Add ansible-test unit test meta session that runs ansible-test units
@@ -559,6 +619,11 @@ def add_all_ansible_test_unit_test_sessions(
     """
     parsed_min_version, parsed_max_version, parsed_except_versions = (
         _parse_min_max_except(min_version, max_version, except_versions)
+    )
+    effective_min_python_version = (
+        _get_effective_min_python_version(min_python_version=None)
+        if split_by_python_version
+        else "default"
     )
 
     units_sessions = []
@@ -570,14 +635,32 @@ def add_all_ansible_test_unit_test_sessions(
         except_versions=parsed_except_versions,
     ):
         name = f"ansible-test-units-{ansible_core_version}"
-        add_ansible_test_unit_test_session(
-            name=name,
-            description=f"Run unit tests with ansible-core {ansible_core_version}'s ansible-test",
-            ansible_core_version=ansible_core_version,
-            register_extra_data={"display-name": f"Ⓐ{ansible_core_version}"},
-            default=False,
-        )
-        units_sessions.append(name)
+        if split_by_python_version:
+            py_versions = _get_python_versions(
+                ansible_core_version=ansible_core_version,
+                effective_min_python_version=effective_min_python_version,
+                core_python_versions=core_python_versions,
+                controller_python_versions_only=controller_python_versions_only,
+            )
+            units_sessions.extend(
+                _add_ansible_test_unit_test_session_group(
+                    name_prefix=name,
+                    description_prefix=f"Run unit tests with ansible-core {ansible_core_version}'s"
+                    " ansible-test",
+                    ansible_core_version=ansible_core_version,
+                    python_versions=py_versions,
+                )
+            )
+        else:
+            add_ansible_test_unit_test_session(
+                name=name,
+                description=f"Run unit tests with ansible-core {ansible_core_version}'s"
+                " ansible-test",
+                ansible_core_version=ansible_core_version,
+                register_extra_data={"display-name": f"Ⓐ{ansible_core_version}"},
+                default=False,
+            )
+            units_sessions.append(name)
     if add_devel_like_branches:
         for repo_name, branch_name in add_devel_like_branches:
             repo_prefix = (
@@ -585,19 +668,41 @@ def add_all_ansible_test_unit_test_sessions(
             )
             repo_postfix = f", {repo_name} repository" if repo_name is not None else ""
             name = f"ansible-test-units-{repo_prefix}{branch_name.replace('/', '-')}"
-            add_ansible_test_unit_test_session(
-                name=name,
-                description=(
-                    "Run unit tests from ansible-test in ansible-core's"
-                    f" {branch_name} branch{repo_postfix}"
-                ),
-                ansible_core_version="devel",
-                ansible_core_repo_name=repo_name,
-                ansible_core_branch_name=branch_name,
-                register_extra_data={"display-name": f"Ⓐ{branch_name}"},
-                default=False,
-            )
-            units_sessions.append(name)
+            if split_by_python_version:
+                py_versions = _get_python_versions(
+                    ansible_core_version="devel",
+                    effective_min_python_version=effective_min_python_version,
+                    core_python_versions=core_python_versions,
+                    controller_python_versions_only=controller_python_versions_only,
+                    branch_name=branch_name,
+                )
+                units_sessions.extend(
+                    _add_ansible_test_unit_test_session_group(
+                        name_prefix=name,
+                        description_prefix=(
+                            "Run unit tests from ansible-test in ansible-core's"
+                            f" {branch_name} branch{repo_postfix}"
+                        ),
+                        ansible_core_version="devel",
+                        ansible_core_repo_name=repo_name,
+                        ansible_core_branch_name=branch_name,
+                        python_versions=py_versions,
+                    )
+                )
+            else:
+                add_ansible_test_unit_test_session(
+                    name=name,
+                    description=(
+                        "Run unit tests from ansible-test in ansible-core's"
+                        f" {branch_name} branch{repo_postfix}"
+                    ),
+                    ansible_core_version="devel",
+                    ansible_core_repo_name=repo_name,
+                    ansible_core_branch_name=branch_name,
+                    register_extra_data={"display-name": f"Ⓐ{branch_name}"},
+                    default=False,
+                )
+                units_sessions.append(name)
 
     def run_all_unit_tests(
         session: nox.Session,  # pylint: disable=unused-argument

--- a/src/antsibull_nox/sessions/ansible_test.py
+++ b/src/antsibull_nox/sessions/ansible_test.py
@@ -457,6 +457,61 @@ def add_all_ansible_test_sanity_test_sessions(
     )(run_all_sanity_tests)
 
 
+def _get_effective_min_python_version(
+    *, min_python_version: MinPythonVersion | None
+) -> MinPythonVersionConstantsWOATC | Version | t.Callable[[Version], bool]:
+    if min_python_version != "ansible-test-config":
+        return min_python_version or "default"
+    return get_min_python_version(
+        load_ansible_test_config(ignore_errors=True), ignore_errors=True
+    )
+
+
+def _get_python_versions(
+    *,
+    ansible_core_version: AnsibleCoreVersion,
+    effective_min_python_version: (
+        MinPythonVersionConstantsWOATC | Version | t.Callable[[Version], bool]
+    ),
+    core_python_versions: dict[str | AnsibleCoreVersion, list[str | Version]] | None,
+    controller_python_versions_only: bool,
+    branch_name: str | None = None,
+) -> list[str | Version]:
+    # Determine Python versions to run tests for
+    if core_python_versions:
+        py_versions = (
+            (core_python_versions.get(branch_name) if branch_name is not None else None)
+            or core_python_versions.get(ansible_core_version)
+            or core_python_versions.get(str(ansible_core_version))
+        )
+        if py_versions is not None:
+            return py_versions
+    core_info = get_ansible_core_info(ansible_core_version)
+    effective_py_versions: list[Version] = list(
+        core_info.controller_python_versions
+        if controller_python_versions_only
+        or effective_min_python_version == "controller"
+        else core_info.remote_python_versions
+    )
+    if effective_min_python_version not in ("default", "controller"):
+        if callable(effective_min_python_version):
+            # effective_min_python_version is a predicate
+            effective_py_versions = [
+                pyv
+                for pyv in effective_py_versions
+                if effective_min_python_version(pyv)
+            ]
+        else:
+            # mypy doesn't get this, so we have to use assert()...
+            assert isinstance(effective_min_python_version, Version)
+            effective_py_versions = [
+                pyv
+                for pyv in effective_py_versions
+                if pyv >= effective_min_python_version
+            ]
+    return list(effective_py_versions)
+
+
 def add_ansible_test_unit_test_session(
     *,
     name: str,
@@ -683,15 +738,9 @@ def add_ansible_test_integration_sessions_default_container(
     This is only used when ``core_python_versions`` does not provide an
     explicit list of Python versions.
     """
-    effective_min_python_version: (
-        MinPythonVersionConstantsWOATC | Version | t.Callable[[Version], bool]
+    effective_min_python_version = _get_effective_min_python_version(
+        min_python_version=min_python_version
     )
-    if min_python_version == "ansible-test-config":
-        effective_min_python_version = get_min_python_version(
-            load_ansible_test_config(ignore_errors=True), ignore_errors=True
-        )
-    else:
-        effective_min_python_version = min_python_version or "default"
 
     def callback_before() -> None:
         if not ansible_vars_from_env_vars and not ansible_vars:
@@ -707,38 +756,13 @@ def add_ansible_test_integration_sessions_default_container(
         branch_name: str | None = None,
     ) -> list[str]:
         # Determine Python versions to run tests for
-        py_versions = (
-            (core_python_versions.get(branch_name) if branch_name is not None else None)
-            or core_python_versions.get(ansible_core_version)
-            or core_python_versions.get(str(ansible_core_version))
-            if core_python_versions
-            else None
+        py_versions = _get_python_versions(
+            ansible_core_version=ansible_core_version,
+            effective_min_python_version=effective_min_python_version,
+            core_python_versions=core_python_versions,
+            controller_python_versions_only=controller_python_versions_only,
+            branch_name=branch_name,
         )
-        if py_versions is None:
-            core_info = get_ansible_core_info(ansible_core_version)
-            effective_py_versions: list[Version] = list(
-                core_info.controller_python_versions
-                if controller_python_versions_only
-                or effective_min_python_version == "controller"
-                else core_info.remote_python_versions
-            )
-            if effective_min_python_version not in ("default", "controller"):
-                if callable(effective_min_python_version):
-                    # effective_min_python_version is a predicate
-                    effective_py_versions = [
-                        pyv
-                        for pyv in effective_py_versions
-                        if effective_min_python_version(pyv)
-                    ]
-                else:
-                    # mypy doesn't get this, so we have to use assert()...
-                    assert isinstance(effective_min_python_version, Version)
-                    effective_py_versions = [
-                        pyv
-                        for pyv in effective_py_versions
-                        if pyv >= effective_min_python_version
-                    ]
-            py_versions = list(effective_py_versions)
 
         # Add sessions
         integration_sessions_core: list[str] = []

--- a/src/antsibull_nox/sessions/lint.py
+++ b/src/antsibull_nox/sessions/lint.py
@@ -19,6 +19,7 @@ import nox
 from ..collection import (
     load_collection_data_from_disk,
 )
+from ..lint_config import NOXFILE_PY
 from ..messages import Message
 from ..messages.parse import (
     parse_mypy_errors,
@@ -69,7 +70,7 @@ CODE_FILES = [
 CODE_FILES_W_NOXFILE = [
     Path("plugins"),
     Path("tests/unit"),
-    Path("noxfile.py"),
+    Path(NOXFILE_PY),
 ]
 
 MODULE_PATHS = FileCollector.create(


### PR DESCRIPTION
This will be needed for community.general.