### PR TITLE
Update list of supported Python versions

### DIFF
--- a/changelogs/fragments/223-python.yml
+++ b/changelogs/fragments/223-python.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "Add estimated Python versions for ansible-core 2.26 to 2.29, including the 'every 6th release' rule for target Python support
+     (https://github.com/ansible-community/antsibull-nox/pull/223)."

--- a/src/antsibull_nox/ansible.py
+++ b/src/antsibull_nox/ansible.py
@@ -126,6 +126,7 @@ _SUPPORTED_CORE_VERSIONS: dict[Version | t.Literal["milestone"], AnsibleCoreInfo
         "2.22": [
             ["3.13", "3.14", "3.15"],
             # Every 6th release supports seven Python versions on the target
+            # pylint: disable-next=line-too-long
             # (https://docs.ansible.com/projects/ansible-core/devel/reference_appendices/release_and_maintenance.html#ansible-core-target-node-python-support)
             ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15"],
         ],
@@ -152,6 +153,7 @@ _SUPPORTED_CORE_VERSIONS: dict[Version | t.Literal["milestone"], AnsibleCoreInfo
         "2.28": [
             ["3.16", "3.17", "3.18"],
             # Every 6th release supports seven Python versions on the target
+            # pylint: disable-next=line-too-long
             # (https://docs.ansible.com/projects/ansible-core/devel/reference_appendices/release_and_maintenance.html#ansible-core-target-node-python-support)
             ["3.12", "3.13", "3.14", "3.15", "3.16", "3.17", "3.18"],
         ],

--- a/src/antsibull_nox/ansible.py
+++ b/src/antsibull_nox/ansible.py
@@ -125,8 +125,9 @@ _SUPPORTED_CORE_VERSIONS: dict[Version | t.Literal["milestone"], AnsibleCoreInfo
         # It contains commented-out entries for future ansible-core versions.
         "2.22": [
             ["3.13", "3.14", "3.15"],
+            # Every 6th release supports seven Python versions on the target
+            # (https://docs.ansible.com/projects/ansible-core/devel/reference_appendices/release_and_maintenance.html#ansible-core-target-node-python-support)
             ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15"],
-            # ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"],
         ],
         "2.23": [
             ["3.13", "3.14", "3.15"],
@@ -139,6 +140,24 @@ _SUPPORTED_CORE_VERSIONS: dict[Version | t.Literal["milestone"], AnsibleCoreInfo
         "2.25": [
             ["3.14", "3.15", "3.16"],
             ["3.11", "3.12", "3.13", "3.14", "3.15", "3.16"],
+        ],
+        "2.26": [
+            ["3.15", "3.16", "3.17"],
+            ["3.12", "3.13", "3.14", "3.15", "3.16", "3.17"],
+        ],
+        "2.27": [
+            ["3.15", "3.16", "3.17"],
+            ["3.12", "3.13", "3.14", "3.15", "3.16", "3.17"],
+        ],
+        "2.28": [
+            ["3.16", "3.17", "3.18"],
+            # Every 6th release supports seven Python versions on the target
+            # (https://docs.ansible.com/projects/ansible-core/devel/reference_appendices/release_and_maintenance.html#ansible-core-target-node-python-support)
+            ["3.12", "3.13", "3.14", "3.15", "3.16", "3.17", "3.18"],
+        ],
+        "2.29": [
+            ["3.16", "3.17", "3.18"],
+            ["3.13", "3.14", "3.15", "3.16", "3.17", "3.18"],
         ],
     }.items()
 }


### PR DESCRIPTION
I found out today that ansible-core 2.22 will keep supporting Python 3.9, and that there's a "every 6th release" rule I forgot about :)

Ref: https://docs.ansible.com/projects/ansible-core/devel/reference_appendices/release_and_maintenance.html#ansible-core-target-node-python-support
