### PR TITLE
Use Python version range instead of picking a version for ansible-test if new enough nox

### DIFF
--- a/changelogs/fragments/232-ansible-test-nox.yml
+++ b/changelogs/fragments/232-ansible-test-nox.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - "When using nox 2026.08.10 or newer, ansible-test sessions get a range of supported Python versions assigned instead of a single version that's determined from the supported versions and the found Python interpreters.
+     This removes the confusing extra Python version from the session names, and avoids having to re-implement a Python interpreter discovery method similar to nox's
+     (https://github.com/ansible-community/antsibull-nox/pull/232)."

--- a/src/antsibull_nox/sessions/ansible_test.py
+++ b/src/antsibull_nox/sessions/ansible_test.py
@@ -38,6 +38,7 @@ from ..paths.utils import copy_directory_tree_into
 from ..python.versions import get_installed_python_versions
 from ..reporting import get_session_reporter
 from ..utils import Version
+from ..utils.nox import is_nox_newer_than
 from .collections import prepare_collections
 from .utils import (
     IN_CI,
@@ -55,6 +56,8 @@ from .utils.values import (
 if t.TYPE_CHECKING:  # pragma: no cover
     DevelLikeBranch = tuple[str | None, str]
     NeverAlwaysInCI = t.Literal["never", "always", "in-ci"]
+
+    from ..ansible import AnsibleCoreInfo
 
 _ANSIBLE_TEST_PREFER_PODMAN_ENV_VAR = "ANSIBLE_TEST_PREFER_PODMAN"
 _COVERAGE_DESTINATION_ENV_VAR = "ANTSIBULL_NOX_COVERAGE_DESTINATION"
@@ -184,6 +187,32 @@ def _run_ansible_test_env_setup(
     session.run(*env_command, env=env_env)
 
 
+def _pick_python_version(core_info: AnsibleCoreInfo) -> str | list[str]:
+    if is_nox_newer_than(Version(2026, 8)):
+        # Python ranges need https://github.com/wntrblm/nox/pull/1086,
+        # which appears in 2026.08.10
+        # (https://github.com/wntrblm/nox/releases/tag/2026.08.10)
+        min_py = min(core_info.controller_python_versions)
+        max_py_p1 = max(core_info.controller_python_versions).next_minor_version()
+        return f">={min_py},<{max_py_p1}"
+
+    # Compatibility for older nox versions: figure out the installed Python
+    # versions, and pick the largest one installed that is supported by
+    # ansible-core on the controller side.
+    all_versions = get_installed_python_versions()
+
+    installed_versions = [
+        version
+        for version in core_info.controller_python_versions
+        if version in all_versions
+    ]
+    # If there's none, simply pick the largest one supported by ansible-core
+    # on the controller side.
+    python = max(installed_versions or core_info.controller_python_versions)
+    python_versions = [python]
+    return [str(python_version) for python_version in python_versions]
+
+
 # NOTE: This is publicly documented API!
 # Any change to the API must not be breaking, and must be
 # updated in docs/reference.md!
@@ -301,23 +330,15 @@ def add_ansible_test_session(
                     cwd / "tests" / "output",
                 )
 
-    # Determine Python version(s)
+    # Determine Python version (range)
     core_info = get_ansible_core_info(parsed_ansible_core_version)
-    all_versions = get_installed_python_versions()
-
-    installed_versions = [
-        version
-        for version in core_info.controller_python_versions
-        if version in all_versions
-    ]
-    python = max(installed_versions or core_info.controller_python_versions)
-    python_versions = [python]
+    python_arg = _pick_python_version(core_info)
 
     run_ansible_test.__doc__ = description
     nox.session(
         name=name,
         default=default,
-        python=[str(python_version) for python_version in python_versions],
+        python=python_arg,
     )(run_ansible_test)
 
     if register_name:
@@ -328,7 +349,7 @@ def add_ansible_test_session(
                 if ansible_core_branch_name is not None
                 else str(parsed_ansible_core_version)
             ),
-            "python": " ".join(str(python) for python in python_versions),
+            "python": str(max(core_info.controller_python_versions)),
         }
         if register_extra_data:
             data.update(register_extra_data)

--- a/src/antsibull_nox/utils/nox.py
+++ b/src/antsibull_nox/utils/nox.py
@@ -1,0 +1,43 @@
+# Author: Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026, Ansible Project
+
+"""
+Information on nox.
+"""
+
+from __future__ import annotations
+
+import functools
+from importlib.metadata import PackageNotFoundError, version
+
+from . import Version
+
+
+def _get_package_version(package: str) -> Version | None:
+    try:
+        return Version.parse(version(package))
+    except PackageNotFoundError:
+        return None
+
+
+@functools.cache
+def get_nox_version() -> Version | None:
+    """
+    Get the (major and minor part of the) nox version.
+    """
+    return _get_package_version("nox")
+
+
+def is_nox_newer_than(newer_than_version: Version) -> bool:
+    """
+    Query whether nox is newer (or equally new) than the given version.
+    """
+    nox_version = get_nox_version()
+    if nox_version is None:
+        # If there is no version, we assume it's the latest sources of nox,
+        # and thus newer than whatever we ask for.
+        return True
+    return nox_version >= newer_than_version


### PR DESCRIPTION
Now that https://github.com/wntrblm/nox/pull/1086#event-28147006292 was merged into nox's `main` branch, we can prepare using it! :tada:

This finally fixes https://github.com/ansible-community/antsibull-nox/issues/5#issuecomment-2746245397 in a proper way.

TODOs:
- [x] Adjust the version number that introduces the feature into a nox release once there is a new nox release.