### PR TITLE
Fix integration tests

### DIFF
--- a/tests/coverage-collection/antsibull-nox.toml
+++ b/tests/coverage-collection/antsibull-nox.toml
@@ -23,6 +23,7 @@ run_black = true
 run_ruff_format = true
 run_ruff_autofix = true
 run_ruff_check = true
+ruff_config = "ruff.toml"
 run_flake8 = true
 run_pylint = true
 run_yamllint = true

--- a/tests/coverage-collection/ruff.toml
+++ b/tests/coverage-collection/ruff.toml
@@ -1,0 +1,11 @@
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2025 Felix Fontein <felix@fontein.de>
+
+[lint]
+# https://docs.astral.sh/ruff/rules/
+
+ignore = [
+    "EXE001",
+    "RUF100",
+]


### PR DESCRIPTION
They currently fail, likely due to a new ruff version.

Ref: https://github.com/ansible-community/antsibull-nox/actions/runs/30243902069