### PR TITLE
Pin all actions not under control by gh.com/ansible-community

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -45,18 +45,18 @@ jobs:
     name: "Run nox ${{ matrix.session }} session"
     steps:
       - name: Check out antsibull-nox
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           path: antsibull-nox
           persist-credentials: false
       - name: Check out dependent project antsibull-docutils
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: ansible-community/antsibull-docutils
           path: antsibull-docutils
           persist-credentials: false
       - name: Check out dependent project antsibull-fileutils
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: ansible-community/antsibull-fileutils
           path: antsibull-fileutils
@@ -66,7 +66,7 @@ jobs:
         run: |
           sudo apt-get install -y ${{ matrix.packages }}
       - name: Setup nox
-        uses: wntrblm/nox@2026.07.11
+        uses: wntrblm/nox@3284968a16fa5bd7fc0cc64a69a531404ccb4756  # 2026.07.11
         with:
           python-versions: "${{ matrix.python-versions }}"
       - name: Run nox

--- a/.github/workflows/reusable-nox-matrix.yml
+++ b/.github/workflows/reusable-nox-matrix.yml
@@ -148,7 +148,7 @@ jobs:
       change-detection-base-branch: ${{ steps.determine-parameters.outputs.change-detection-base-branch }}
     steps:
       - name: Check out collection
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 3
           persist-credentials: false
@@ -284,7 +284,7 @@ jobs:
       - name: Check out collection
         if: >-
           !matrix.skip
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: ${{ needs.create-matrixes.outputs.change-detection == 'true' && '0' || '1' }}
@@ -330,7 +330,7 @@ jobs:
       - name: Upload coverage for final step
         if: >-
           !matrix.skip && needs.create-matrixes.outputs.upload-codecov == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: code-coverage-sanity-${{ matrix.name }}
           path: ${{ inputs.collection-root }}/tests/output/reports/coverage=sanity=*.xml
@@ -350,7 +350,7 @@ jobs:
       - name: Check out collection
         if: >-
           !matrix.skip
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: ${{ needs.create-matrixes.outputs.change-detection == 'true' && '0' || '1' }}
@@ -396,7 +396,7 @@ jobs:
       - name: Upload coverage for final step
         if: >-
           !matrix.skip && needs.create-matrixes.outputs.upload-codecov == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: code-coverage-units-${{ matrix.name }}
           path: ${{ inputs.collection-root }}/tests/output/reports/coverage=units=*.xml
@@ -417,7 +417,7 @@ jobs:
       - name: Check out collection
         if: >-
           !matrix.skip
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: ${{ needs.create-matrixes.outputs.change-detection == 'true' && '0' || '1' }}
@@ -464,7 +464,7 @@ jobs:
       - name: Upload coverage for final step
         if: >-
           !matrix.skip && needs.create-matrixes.outputs.upload-codecov == 'true' && (matrix.has-coverage != 'false')
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: code-coverage-integration-${{ matrix.name }}
           path: ${{ inputs.collection-root }}/tests/output/reports/coverage=integration=*.xml
@@ -479,11 +479,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out collection
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
       - name: Download coverage from previous steps
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: code-coverage-*
       - name: List all files
@@ -491,7 +491,7 @@ jobs:
         shell: bash
         working-directory: ${{ inputs.collection-root }}
       - name: Upload coverage
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           files: coverage=*.xml
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -514,7 +514,7 @@ jobs:
       - name: Check out collection
         if: >-
           !matrix.skip
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
       - name: Run a pre-test command

--- a/.github/workflows/reusable-nox-run.yml
+++ b/.github/workflows/reusable-nox-run.yml
@@ -104,7 +104,7 @@ jobs:
           set_output("change-detection", json.dumps(change_detection))
           set_output("change-detection-base-branch", change_detection_base_branch)
       - name: Check out collection
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: ${{ steps.determine-parameters.outputs.change-detection == 'true' && '0' || '1' }}

--- a/.github/workflows/test-gh-action.yml
+++ b/.github/workflows/test-gh-action.yml
@@ -34,7 +34,7 @@ jobs:
           - "3.14"
     steps:
       - name: Check out antsibull-nox
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
       - name: Run nox action in subdirectory
@@ -59,7 +59,7 @@ jobs:
     name: "Run nox"
     steps:
       - name: Check out antsibull-nox
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
       - name: Run nox action in subdirectory

--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
   using: composite
   steps:
     - name: "Install Python ${{ inputs.python-version }}"
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       id: python
       with:
         python-version: |-

--- a/changelogs/fragments/236-action-pin.yml
+++ b/changelogs/fragments/236-action-pin.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "The action and shared workflows now pin all GitHub Actions that are not under direct control of github.com/ansible-community (https://github.com/ansible-community/antsibull-nox/pull/236)."

--- a/docs/nox-in-ci.md
+++ b/docs/nox-in-ci.md
@@ -54,7 +54,7 @@ jobs:
     name: "Run nox"
     steps:
       - name: Check out collection
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Run nox


### PR DESCRIPTION
Together with https://github.com/ansible-community/github-action-run-nox/pull/18, this pins all actions that aren't under direct control of the Ansible community.

Note that actions refering to the antsibull-nox repository (from the shared workflows) do not use pins:
- `ansible-community/github-action-run-nox@v1`
- `ansible-community/antsibull-nox@main`

Also the action installs the latest version of nox from PyPI (https://github.com/ansible-community/antsibull-nox/blob/main/action.yml#L118). At some point, we should have pinned requirements files for all Python versions we support, and use these.
