### PR TITLE
Reference own shared workflows and action through new reference syntax

### DIFF
--- a/.github/workflows/reusable-nox-matrix.yml
+++ b/.github/workflows/reusable-nox-matrix.yml
@@ -258,7 +258,7 @@ jobs:
           set_output("upload-codecov", json.dumps(upload_codecov))
           set_output("extra-args", " ".join(extra_args))
       - name: Run nox
-        uses: ansible-community/antsibull-nox@main
+        uses: $/
         id: generate-matrix
         with:
           change-detection: ${{ steps.determine-parameters.outputs.change-detection }}
@@ -319,7 +319,7 @@ jobs:
       - name: Run nox
         if: >-
           !matrix.skip
-        uses: ansible-community/antsibull-nox@main
+        uses: $/
         with:
           change-detection: ${{ needs.create-matrixes.outputs.change-detection }}
           change-detection-base-branch: ${{ needs.create-matrixes.outputs.change-detection-base-branch }}
@@ -385,7 +385,7 @@ jobs:
       - name: Run nox
         if: >-
           !matrix.skip
-        uses: ansible-community/antsibull-nox@main
+        uses: $/
         with:
           change-detection: ${{ needs.create-matrixes.outputs.change-detection }}
           change-detection-base-branch: ${{ needs.create-matrixes.outputs.change-detection-base-branch }}
@@ -452,7 +452,7 @@ jobs:
       - name: Run nox
         if: >-
           !matrix.skip
-        uses: ansible-community/antsibull-nox@main
+        uses: $/
         with:
           allow-unstable-changed: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
           change-detection: ${{ needs.create-matrixes.outputs.change-detection }}
@@ -532,7 +532,7 @@ jobs:
       - name: Run nox
         if: >-
           !matrix.skip
-        uses: ansible-community/antsibull-nox@main
+        uses: $/
         with:
           sessions: ${{ matrix.name }}
           working-directory: ${{ inputs.collection-root }}

--- a/.github/workflows/reusable-nox-run.yml
+++ b/.github/workflows/reusable-nox-run.yml
@@ -130,7 +130,7 @@ jobs:
           ${{ inputs.pre-test-cmd }}
         working-directory: ${{ inputs.collection-root }}
       - name: Run nox
-        uses: ansible-community/antsibull-nox@main
+        uses: $/
         with:
           change-detection: ${{ steps.determine-parameters.outputs.change-detection }}
           change-detection-base-branch: ${{ steps.determine-parameters.outputs.change-detection-base-branch }}

--- a/.github/workflows/test-gh-action.yml
+++ b/.github/workflows/test-gh-action.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run nox action in subdirectory
-        uses: ./
+        uses: $/
         with:
           working-directory: tests/coverage-collection/
           python-version: ${{ matrix.python }}
@@ -63,19 +63,19 @@ jobs:
         with:
           persist-credentials: false
       - name: Run nox action in subdirectory
-        uses: ./
+        uses: $/
         with:
           working-directory: tests/test-collection/
 
   nox:
-    uses: ./.github/workflows/reusable-nox-run.yml
+    uses: $/.github/workflows/reusable-nox-run.yml
     with:
       session-name: Run extra sanity tests
       change-detection-in-prs: true
       collection-root: tests/test-collection/
 
   ansible-test:
-    uses: ./.github/workflows/reusable-nox-matrix.yml
+    uses: $/.github/workflows/reusable-nox-matrix.yml
     with:
       change-detection-in-prs: true
       collection-root: tests/test-collection/

--- a/changelogs/fragments/237-action-ref.yml
+++ b/changelogs/fragments/237-action-ref.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "The shared workflows now pin the action from this repository by using a `new GitHub Action reference syntax <https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/>`__ (https://github.com/ansible-community/antsibull-nox/pull/237)."


### PR DESCRIPTION
https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/

Thanks to @briantist for mentioning this in https://github.com/ansible-community/github-docs-build/issues/122.