### PR TITLE
Add a top-level version field to the config file format

### DIFF
--- a/changelogs/fragments/239-config-version.yml
+++ b/changelogs/fragments/239-config-version.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Add a top-level ``version`` field to the config file format (https://github.com/ansible-community/antsibull-nox/pull/239)."

--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -85,14 +85,14 @@ Otherwise `antsibull-nox.toml` will be ignored.
 ## Configuration file version
 
 The top-level `version` field currently accepts the value `1` only.
-We recommend setting `version = 1` in your existing configuration because `antsibull-nox` version 2.0.0 will require it.
+We recommend setting `version = 1` in your existing configuration
+because `antsibull-nox` version 2.0.0 will require it.
 
-The `version` field lets `antsibull-nox` introduce backwards-incompatible changes to the configuration file format, which users must explicitly opt in to receive.
+The `version` field lets `antsibull-nox` introduce backwards-incompatible changes to the configuration file format,
+which users must explicitly opt in to receive.
 
-`antsibull-nox` will never remove support for a specific configuration file format version without a deprecation period or outside of a new major release.
-
-For now,
-we recommend to set `version` to `1` in existing configs.
+`antsibull-nox` will never remove support for a specific configuration file format version
+without a deprecation period or outside of a new major release.
 
 ## General collection configuration
 

--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -17,6 +17,8 @@ A basic `antsibull-nox.toml` looks as follows:
 ```toml
 # Comments start with a '#', similar to YAML or Python.
 
+version = 1
+
 [collection]
 # Use ansible-test's config file (tests/config.yml) to determine which
 # Python versions to use when generating test matrixes.
@@ -79,6 +81,20 @@ validate_collection_refs="all"
 
 Make sure that your `noxfile.py` contains the `antsibull_nox.load_antsibull_nox_toml()` function call.
 Otherwise `antsibull-nox.toml` will be ignored.
+
+## Configuration file version
+
+The top-level `version` field only accepts the value `1` right now.
+We recommend that the field is provided;
+antsibull-nox 2.0.0 will require it.
+
+The version field allows to make backwards-incompatible changes to the configuration file format
+that users of antsibull-nox have to explicitly opt in.
+antsibull-nox will never remove support for a specific configuration file format version
+without a deprecation period and outside of a new major release.
+
+For now,
+we recommend to set `version` to `1` in existing configs.
 
 ## General collection configuration
 

--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -84,14 +84,12 @@ Otherwise `antsibull-nox.toml` will be ignored.
 
 ## Configuration file version
 
-The top-level `version` field only accepts the value `1` right now.
-We recommend that the field is provided;
-antsibull-nox 2.0.0 will require it.
+The top-level `version` field currently accepts the value `1` only.
+We recommend setting `version = 1` in your existing configuration because `antsibull-nox` version 2.0.0 will require it.
 
-The version field allows to make backwards-incompatible changes to the configuration file format
-that users of antsibull-nox have to explicitly opt in.
-antsibull-nox will never remove support for a specific configuration file format version
-without a deprecation period and outside of a new major release.
+The `version` field lets `antsibull-nox` introduce backwards-incompatible changes to the configuration file format, which users must explicitly opt in to receive.
+
+`antsibull-nox` will never remove support for a specific configuration file format version without a deprecation period or outside of a new major release.
 
 For now,
 we recommend to set `version` to `1` in existing configs.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -57,6 +57,8 @@ if __name__ == "__main__":
 
 The **`antsibull-nox.toml`** file:
 ```toml
+version = 1
+
 [sessions]
 
 [sessions.lint]

--- a/src/antsibull_nox/config.py
+++ b/src/antsibull_nox/config.py
@@ -880,6 +880,9 @@ class Config(_BaseModel):
     The contents of a antsibull-nox config file.
     """
 
+    # For now the version is optional, and if not specified defaults to 1.
+    version: t.Optional[t.Literal[1]] = 1
+
     collection_sources: dict[CollectionName, CollectionSource] = {}
     collection_sources_per_ansible: dict[
         PAnsibleCoreVersion, dict[CollectionName, CollectionSource]

--- a/src/antsibull_nox/config.py
+++ b/src/antsibull_nox/config.py
@@ -273,7 +273,7 @@ class SessionLint(_BaseModel):
     pylint_rcfile: t.Optional[p.FilePath] = None
     pylint_modules_rcfile: t.Optional[p.FilePath] = None
     pylint_package: Packages = PackageName(name="pylint")
-    pylint_ansible_core_package: t.Optional[Packages] = PackageName(name="ansible-core")
+    pylint_ansible_core_package: Packages = PackageName(name="ansible-core")
     pylint_extra_deps: list[PackageFieldOrString] = []
 
     # yamllint:
@@ -292,7 +292,7 @@ class SessionLint(_BaseModel):
     mypy_config: t.Optional[p.FilePath] = None
     mypy_modules_config: t.Optional[p.FilePath] = None
     mypy_package: Packages = PackageName(name="mypy")
-    mypy_ansible_core_package: t.Optional[Packages] = PackageName(name="ansible-core")
+    mypy_ansible_core_package: Packages = PackageName(name="ansible-core")
     mypy_extra_deps: list[PackageFieldOrString] = []
 
     # antsibull-nox config lint:
@@ -881,7 +881,7 @@ class Config(_BaseModel):
     """
 
     # For now the version is optional, and if not specified defaults to 1.
-    version: t.Optional[t.Literal[1]] = 1
+    version: t.Literal[1] = 1
 
     collection_sources: dict[CollectionName, CollectionSource] = {}
     collection_sources_per_ansible: dict[

--- a/src/antsibull_nox/init.py
+++ b/src/antsibull_nox/init.py
@@ -46,6 +46,8 @@ if __name__ == "__main__":
 """
 
 CONFIG_CONTENT = r"""
+version = 1
+
 [sessions]
 
 [sessions.lint]


### PR DESCRIPTION
This allows to opt-in into backwards compatibility breaking changes by bumping the config version. This should reduce the need to make major releases, which in turn makes life easier for collection maintainers and users.