### PR TITLE
Support CI=false

### DIFF
--- a/changelogs/fragments/245-ci.yml
+++ b/changelogs/fragments/245-ci.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Allow to explicitly specify that antsibull-nox is not running in an CI environment by setting the ``CI`` environment variable to the string ``false`` (https://github.com/ansible-community/antsibull-nox/pull/245)."

--- a/docs/nox-in-ci.md
+++ b/docs/nox-in-ci.md
@@ -142,3 +142,18 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 ```
+
+## CI detection
+
+Antsibull-nox detects whether it runs in a CI environment as follows:
+
+* If the `CI` environment variable is set to `true`
+  (this is the case for GitHub Actions, GitLab CI, Travis, and others);
+* If the `TF_BUILD` environment variable is set to `True`
+  (this is the case for Azure Pipelines);
+* If the `SYSTEM_COLLECTIONURI` environment variable is set to a string starting with `https://dev.azure.com/`
+  (this is how ansible-test detects Ansible's AZP environment).
+
+If none of these conditions is true, it assumes it runs outside of a CI environment.
+You can explicitly set `CI` to `false` to make antsibull-nox behave as outside of a CI environment,
+even if one of the above conditions holds.

--- a/src/antsibull_nox/sessions/utils/__init__.py
+++ b/src/antsibull_nox/sessions/utils/__init__.py
@@ -32,6 +32,10 @@ def _is_in_ci() -> bool:
     if os.environ.get("CI") == "true":
         return True
 
+    # Allow to explicitly disable CI detection
+    if os.environ.get("CI") == "false":
+        return False
+
     # The following seems to detect Azure Pipelines:
     # https://stackoverflow.com/a/68771148
     # https://stackoverflow.com/a/77218424

--- a/tests/unit/sessions/utils/test_init.py
+++ b/tests/unit/sessions/utils/test_init.py
@@ -40,6 +40,14 @@ def test__is_in_ci() -> None:
                 with set_environ("SYSTEM_COLLECTIONURI", "foobar"):
                     assert _is_in_ci() is False
 
+                # Explicitly force not being in CI environment
+                with set_environ("CI", "false"):  # must be lower-case
+                    with set_environ("TF_BUILD", "True"):
+                        with set_environ(
+                            "SYSTEM_COLLECTIONURI", "https://dev.azure.com/"
+                        ):
+                            assert _is_in_ci() is False
+
                 # Inside CI
                 with set_environ("CI", "true"):
                     assert _is_in_ci() is True


### PR DESCRIPTION
This makes it easier to disable "in CI" detection. Right now one has to (un-)set three different environment variables to achieve this, and this can change at any time if new detections are added. With this PR, there is one stable way to disable detection.